### PR TITLE
Fix deprecated ESPBTUUID::to_string() → to_str()

### DIFF
--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -5,7 +5,7 @@ substitutions:
 esphome:
   name: ${name}
   comment: ${device_description}
-  min_version: 2024.6.0
+  min_version: 2026.1.0
   project:
     name: "syssi.esphome-daly-bms"
     version: 1.3.0
@@ -42,7 +42,8 @@ esp32_ble_tracker:
             ESP_LOGI("ble_adv", "  MAC address: %s", x.address_str().c_str());
             ESP_LOGD("ble_adv", "  Advertised service UUIDs:");
             for (auto uuid : x.get_service_uuids()) {
-              ESP_LOGD("ble_adv", "    - %s", uuid.to_string().c_str());
+              char buf[ESPBTUUID::UUID_STR_LEN];
+              ESP_LOGD("ble_adv", "    - %s", uuid.to_str(buf));
             }
           }
 


### PR DESCRIPTION
Replace uuid.to_string().c_str() with stack-based uuid.to_str(buf) and bump min_version to 2026.1.0 (to_str() added in ESPHome 2026.1.0, to_string() removed in 2026.8.0).