### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/daly_bms_ble/button/__init__.py
+++ b/components/daly_bms_ble/button/__init__.py
@@ -36,9 +36,7 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_RETRIEVE_SETTINGS): button.button_schema(
             DalyButton, icon=ICON_RETRIEVE_SETTINGS
         ),
-        cv.Optional(CONF_RESTART): button.button_schema(
-            DalyButton, icon=ICON_RESTART
-        ),
+        cv.Optional(CONF_RESTART): button.button_schema(DalyButton, icon=ICON_RESTART),
         cv.Optional(CONF_SHUTDOWN): button.button_schema(
             DalyButton, icon=ICON_SHUTDOWN
         ),

--- a/components/daly_bms_ble/button/__init__.py
+++ b/components/daly_bms_ble/button/__init__.py
@@ -35,19 +35,19 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_RETRIEVE_SETTINGS): button.button_schema(
             DalyButton, icon=ICON_RETRIEVE_SETTINGS
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RESTART): button.button_schema(
             DalyButton, icon=ICON_RESTART
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_SHUTDOWN): button.button_schema(
             DalyButton, icon=ICON_SHUTDOWN
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_RESET_CURRENT): button.button_schema(
             DalyButton, icon=ICON_RESET_CURRENT
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_FACTORY_RESET): button.button_schema(
             DalyButton, icon=ICON_FACTORY_RESET
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/daly_bms_ble/number/__init__.py
+++ b/components/daly_bms_ble/number/__init__.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
             DalyNumber,
             icon=ICON_STATE_OF_CHARGE_SETTING,
             unit_of_measurement=UNIT_PERCENT,
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 

--- a/components/daly_bms_ble/switch/__init__.py
+++ b/components/daly_bms_ble/switch/__init__.py
@@ -29,13 +29,13 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BALANCER): switch.switch_schema(
             DalySwitch, icon=ICON_BALANCER
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_CHARGING): switch.switch_schema(
             DalySwitch, icon=ICON_CHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
         cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             DalySwitch, icon=ICON_DISCHARGING
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant