### PR TITLE
Add entity_category to binary sensor schemas

### DIFF
--- a/components/daly_bms_ble/binary_sensor.py
+++ b/components/daly_bms_ble/binary_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_DALY_BMS_BLE_ID, DALY_BMS_BLE_COMPONENT_SCHEMA
 
@@ -21,12 +22,15 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BALANCING): binary_sensor.binary_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             icon="mdi:battery-heart-variant"
         ),
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             icon="mdi:battery-charging"
         ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             icon="mdi:power-plug"
         ),
     }

--- a/components/daly_bms_ble/binary_sensor.py
+++ b/components/daly_bms_ble/binary_sensor.py
@@ -22,16 +22,13 @@ BINARY_SENSORS = [
 CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BALANCING): binary_sensor.binary_sensor_schema(
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            icon="mdi:battery-heart-variant"
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon="mdi:battery-heart-variant"
         ),
         cv.Optional(CONF_CHARGING): binary_sensor.binary_sensor_schema(
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            icon="mdi:battery-charging"
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon="mdi:battery-charging"
         ),
         cv.Optional(CONF_DISCHARGING): binary_sensor.binary_sensor_schema(
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            icon="mdi:power-plug"
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon="mdi:power-plug"
         ),
     }
 )


### PR DESCRIPTION
Add entity_category=ENTITY_CATEGORY_DIAGNOSTIC to all binary sensors (they report hardware state and protection events). Primary functional switches (charging, discharging, balancer) remain uncategorized. This improves the Home Assistant entity list organization.