### PR TITLE
Fix bitmask sensor

### DIFF
--- a/components/daly_bms_ble/sensor.py
+++ b/components/daly_bms_ble/sensor.py
@@ -215,7 +215,7 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
             unit_of_measurement=UNIT_EMPTY,
             icon=ICON_ERROR_BITMASK,
             accuracy_decimals=0,
-            device_class=None,
+            device_class=DEVICE_CLASS_EMPTY,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
         cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(


### PR DESCRIPTION
`device_class=None` is not a valid value in ESPHome's sensor schema and causes a validation error:

```
string value is None.
Error: Process completed with exit code 2.
```

Replace with `DEVICE_CLASS_EMPTY` which is the correct constant for sensors without a device class.