### PR TITLE
Use STATE_CLASS_TOTAL_INCREASING for charging_cycles sensor

### DIFF
--- a/components/daly_bms_ble/sensor.py
+++ b/components/daly_bms_ble/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_EMPTY,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_EMPTY,
@@ -229,7 +230,7 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
             icon=ICON_CHARGING_CYCLES,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_EMPTY,
-            state_class=STATE_CLASS_MEASUREMENT,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional(CONF_MIN_CELL_VOLTAGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_VOLT,


### PR DESCRIPTION
## Summary

- `charging_cycles` is a cumulative, monotonically increasing counter and should use `STATE_CLASS_TOTAL_INCREASING` instead of `STATE_CLASS_MEASUREMENT`