### PR TITLE
Initialize BLE char handle members to 0

### DIFF
--- a/components/daly_bms_ble/daly_bms_ble.h
+++ b/components/daly_bms_ble/daly_bms_ble.h
@@ -153,8 +153,8 @@ class DalyBmsBle : public esphome::ble_client::BLEClientNode, public PollingComp
     sensor::Sensor *temperature_sensor_{nullptr};
   } temperatures_[8];
 
-  uint16_t char_notify_handle_;
-  uint16_t char_command_handle_;
+  uint16_t char_notify_handle_{0};
+  uint16_t char_command_handle_{0};
   uint32_t password_ = 12345678;
   uint8_t status_registers_{62};
 


### PR DESCRIPTION
## Summary

- `char_notify_handle_` and `char_command_handle_` were declared without initializers, leaving them with indeterminate values from construction until the first BLE connection.
- Adds `{0}` in-class member initializers to guarantee a defined state at construction.