### PR TITLE
Fix text_sensor_schema positional arg and add diagnostic entity category

### DIFF
--- a/components/daly_bms_ble/text_sensor.py
+++ b/components/daly_bms_ble/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_DALY_BMS_BLE_ID, DALY_BMS_BLE_COMPONENT_SCHEMA
 
@@ -22,12 +23,11 @@ TEXT_SENSORS = [
 CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_BATTERY_STATUS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_BATTERY_STATUS,
         ),
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor,
             icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }
 )


### PR DESCRIPTION
## Summary

- Remove positional `text_sensor.TextSensor` argument from `text_sensor_schema(...)` calls (T1)
- Add `entity_category=ENTITY_CATEGORY_DIAGNOSTIC` to `errors` sensor (T2)

Follows the pattern established in `esphome-tianpower-bms`.