### PR TITLE
Explicitly declare ble_client as a component dependency

### DIFF
--- a/components/daly_bms_ble/__init__.py
+++ b/components/daly_bms_ble/__init__.py
@@ -4,7 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PASSWORD
 
 CODEOWNERS = ["@syssi"]
-
+DEPENDENCIES = ["ble_client"]
 AUTO_LOAD = ["binary_sensor", "button", "number", "sensor", "text_sensor", "switch"]
 MULTI_CONF = True
 


### PR DESCRIPTION
## Summary

Add \`DEPENDENCIES = ["ble_client"]\` to \`__init__.py\` to explicitly declare the dependency on \`ble_client\`.

All components in ESPHome core that use \`BLE_CLIENT_SCHEMA\` declare this dependency (e.g. \`airthings_wave_base\`, \`bedjet\`, \`pvvx_mithermometer\`). This makes the requirement explicit and consistent with the upstream pattern.