### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -9,6 +9,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-daly-bms"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -63,180 +63,180 @@ binary_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     balancing:
-      name: "${name} balancing"
+      name: "balancing"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
 
 button:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     # Retrieves the BMS settings and prints them in the ESPHome logs
     retrieve_settings:
-      name: "${name} retrieve settings"
+      name: "retrieve settings"
     # Restarts the BMS
     restart:
-      name: "${name} restart"
+      name: "restart"
     # Shuts down the BMS
     shutdown:
-      name: "${name} shutdown"
+      name: "shutdown"
     # Resets the BMS to the factory settings
     factory_reset:
-      name: "${name} factory reset"
+      name: "factory reset"
     # Resets the BMS current to zero
     reset_current:
-      name: "${name} reset current"
+      name: "reset current"
 
 sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} temperature 5"
+      name: "temperature 5"
     temperature_6:
-      name: "${name} temperature 6"
+      name: "temperature 6"
     temperature_7:
-      name: "${name} temperature 7"
+      name: "temperature 7"
     temperature_8:
-      name: "${name} temperature 8"
+      name: "temperature 8"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     cell_voltage_17:
-      name: "${name} cell voltage 17"
+      name: "cell voltage 17"
     cell_voltage_18:
-      name: "${name} cell voltage 18"
+      name: "cell voltage 18"
     cell_voltage_19:
-      name: "${name} cell voltage 19"
+      name: "cell voltage 19"
     cell_voltage_20:
-      name: "${name} cell voltage 20"
+      name: "cell voltage 20"
     cell_voltage_21:
-      name: "${name} cell voltage 21"
+      name: "cell voltage 21"
     cell_voltage_22:
-      name: "${name} cell voltage 22"
+      name: "cell voltage 22"
     cell_voltage_23:
-      name: "${name} cell voltage 23"
+      name: "cell voltage 23"
     cell_voltage_24:
-      name: "${name} cell voltage 24"
+      name: "cell voltage 24"
     cell_voltage_25:
-      name: "${name} cell voltage 25"
+      name: "cell voltage 25"
     cell_voltage_26:
-      name: "${name} cell voltage 26"
+      name: "cell voltage 26"
     cell_voltage_27:
-      name: "${name} cell voltage 27"
+      name: "cell voltage 27"
     cell_voltage_28:
-      name: "${name} cell voltage 28"
+      name: "cell voltage 28"
     cell_voltage_29:
-      name: "${name} cell voltage 29"
+      name: "cell voltage 29"
     cell_voltage_30:
-      name: "${name} cell voltage 30"
+      name: "cell voltage 30"
     cell_voltage_31:
-      name: "${name} cell voltage 31"
+      name: "cell voltage 31"
     cell_voltage_32:
-      name: "${name} cell voltage 32"
+      name: "cell voltage 32"
     cell_count:
-      name: "${name} cell count"
+      name: "cell count"
     temperature_sensors:
-      name: "${name} temperature sensors"
+      name: "temperature sensors"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
     balance_current:
-      name: "${name} balance current"
+      name: "balance current"
     mosfet_temperature:
-      name: "${name} mosfet temperature"
+      name: "mosfet temperature"
     board_temperature:
-      name: "${name} board temperature"
+      name: "board temperature"
 
 number:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     state_of_charge_setting:
-      name: "${name} state of charge setting"
+      name: "state of charge setting"
 
 switch:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     balancer:
-      name: "${name} balancer"
+      name: "balancer"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
 
   - platform: ble_client
     ble_client_id: client0
-    name: "${name} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
 
 text_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     battery_status:
-      name: "${name} battery status"
+      name: "battery status"
     errors:
-      name: "${name} errors"
+      name: "errors"

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-daly-bms"

--- a/esp32-ble-scanner.yaml
+++ b/esp32-ble-scanner.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   project:
     name: "syssi.esphome-daly-bms"

--- a/tests/esp32-ble-alarms-faker.yaml
+++ b/tests/esp32-ble-alarms-faker.yaml
@@ -369,6 +369,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/tests/esp32-ble-alarms-faker.yaml
+++ b/tests/esp32-ble-alarms-faker.yaml
@@ -414,10 +414,10 @@ sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
 
 text_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     errors:
-      name: "${name} errors"
+      name: "errors"

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2025.6.0
 

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -50,161 +50,161 @@ binary_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     balancing:
-      name: "${name} balancing"
+      name: "balancing"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"
 
 button:
   - platform: daly_bms_ble
     # Retrieves the BMS settings and prints them in the ESPHome logs
     retrieve_settings:
-      name: "${name} retrieve settings"
+      name: "retrieve settings"
     # Restarts the BMS
     restart:
-      name: "${name} restart"
+      name: "restart"
     # Shuts down the BMS
     shutdown:
-      name: "${name} shutdown"
+      name: "shutdown"
     # Resets the BMS to the factory settings
     factory_reset:
-      name: "${name} factory reset"
+      name: "factory reset"
     # Resets the BMS current to zero
     reset_current:
-      name: "${name} reset current"
+      name: "reset current"
 
 sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     error_bitmask:
-      name: "${name} error bitmask"
+      name: "error bitmask"
     total_voltage:
-      name: "${name} total voltage"
+      name: "total voltage"
     current:
-      name: "${name} current"
+      name: "current"
     power:
-      name: "${name} power"
+      name: "power"
     charging_power:
-      name: "${name} charging power"
+      name: "charging power"
     discharging_power:
-      name: "${name} discharging power"
+      name: "discharging power"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     charging_cycles:
-      name: "${name} charging cycles"
+      name: "charging cycles"
     min_cell_voltage:
-      name: "${name} min cell voltage"
+      name: "min cell voltage"
     max_cell_voltage:
-      name: "${name} max cell voltage"
+      name: "max cell voltage"
     min_voltage_cell:
-      name: "${name} min voltage cell"
+      name: "min voltage cell"
     max_voltage_cell:
-      name: "${name} max voltage cell"
+      name: "max voltage cell"
     delta_cell_voltage:
-      name: "${name} delta cell voltage"
+      name: "delta cell voltage"
     average_cell_voltage:
-      name: "${name} average cell voltage"
+      name: "average cell voltage"
     temperature_1:
-      name: "${name} temperature 1"
+      name: "temperature 1"
     temperature_2:
-      name: "${name} temperature 2"
+      name: "temperature 2"
     temperature_3:
-      name: "${name} temperature 3"
+      name: "temperature 3"
     temperature_4:
-      name: "${name} temperature 4"
+      name: "temperature 4"
     temperature_5:
-      name: "${name} temperature 5"
+      name: "temperature 5"
     temperature_6:
-      name: "${name} temperature 6"
+      name: "temperature 6"
     temperature_7:
-      name: "${name} temperature 7"
+      name: "temperature 7"
     temperature_8:
-      name: "${name} temperature 8"
+      name: "temperature 8"
     cell_voltage_1:
-      name: "${name} cell voltage 1"
+      name: "cell voltage 1"
     cell_voltage_2:
-      name: "${name} cell voltage 2"
+      name: "cell voltage 2"
     cell_voltage_3:
-      name: "${name} cell voltage 3"
+      name: "cell voltage 3"
     cell_voltage_4:
-      name: "${name} cell voltage 4"
+      name: "cell voltage 4"
     cell_voltage_5:
-      name: "${name} cell voltage 5"
+      name: "cell voltage 5"
     cell_voltage_6:
-      name: "${name} cell voltage 6"
+      name: "cell voltage 6"
     cell_voltage_7:
-      name: "${name} cell voltage 7"
+      name: "cell voltage 7"
     cell_voltage_8:
-      name: "${name} cell voltage 8"
+      name: "cell voltage 8"
     cell_voltage_9:
-      name: "${name} cell voltage 9"
+      name: "cell voltage 9"
     cell_voltage_10:
-      name: "${name} cell voltage 10"
+      name: "cell voltage 10"
     cell_voltage_11:
-      name: "${name} cell voltage 11"
+      name: "cell voltage 11"
     cell_voltage_12:
-      name: "${name} cell voltage 12"
+      name: "cell voltage 12"
     cell_voltage_13:
-      name: "${name} cell voltage 13"
+      name: "cell voltage 13"
     cell_voltage_14:
-      name: "${name} cell voltage 14"
+      name: "cell voltage 14"
     cell_voltage_15:
-      name: "${name} cell voltage 15"
+      name: "cell voltage 15"
     cell_voltage_16:
-      name: "${name} cell voltage 16"
+      name: "cell voltage 16"
     cell_voltage_17:
-      name: "${name} cell voltage 17"
+      name: "cell voltage 17"
     cell_voltage_18:
-      name: "${name} cell voltage 18"
+      name: "cell voltage 18"
     cell_voltage_19:
-      name: "${name} cell voltage 19"
+      name: "cell voltage 19"
     cell_voltage_20:
-      name: "${name} cell voltage 20"
+      name: "cell voltage 20"
     cell_voltage_21:
-      name: "${name} cell voltage 21"
+      name: "cell voltage 21"
     cell_voltage_22:
-      name: "${name} cell voltage 22"
+      name: "cell voltage 22"
     cell_voltage_23:
-      name: "${name} cell voltage 23"
+      name: "cell voltage 23"
     cell_voltage_24:
-      name: "${name} cell voltage 24"
+      name: "cell voltage 24"
     cell_voltage_25:
-      name: "${name} cell voltage 25"
+      name: "cell voltage 25"
     cell_voltage_26:
-      name: "${name} cell voltage 26"
+      name: "cell voltage 26"
     cell_voltage_27:
-      name: "${name} cell voltage 27"
+      name: "cell voltage 27"
     cell_voltage_28:
-      name: "${name} cell voltage 28"
+      name: "cell voltage 28"
     cell_voltage_29:
-      name: "${name} cell voltage 29"
+      name: "cell voltage 29"
     cell_voltage_30:
-      name: "${name} cell voltage 30"
+      name: "cell voltage 30"
     cell_voltage_31:
-      name: "${name} cell voltage 31"
+      name: "cell voltage 31"
     cell_voltage_32:
-      name: "${name} cell voltage 32"
+      name: "cell voltage 32"
     cell_count:
-      name: "${name} cell count"
+      name: "cell count"
     temperature_sensors:
-      name: "${name} temperature sensors"
+      name: "temperature sensors"
     capacity_remaining:
-      name: "${name} capacity remaining"
+      name: "capacity remaining"
 
 text_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     battery_status:
-      name: "${name} battery status"
+      name: "battery status"
     errors:
-      name: "${name} errors"
+      name: "errors"
 
 switch:
   - platform: daly_bms_ble
     balancer:
-      name: "${name} balancer"
+      name: "balancer"
     charging:
-      name: "${name} charging"
+      name: "charging"
     discharging:
-      name: "${name} discharging"
+      name: "discharging"


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.