### PR TITLE
Remove redundant device name prefix from entity names

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -81,25 +81,25 @@ binary_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     balancing:
-      name: "${bms0} balancing"
+      name: "balancing"
       device_id: device0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
       device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
       device_id: device0
 
   - platform: daly_bms_ble
     daly_bms_ble_id: bms1
     balancing:
-      name: "${bms1} balancing"
+      name: "balancing"
       device_id: device1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
       device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
       device_id: device1
 
 button:
@@ -107,426 +107,426 @@ button:
     daly_bms_ble_id: bms0
     # Retrieves the BMS settings and prints them in the ESPHome logs
     retrieve_settings:
-      name: "${bms0} retrieve settings"
+      name: "retrieve settings"
       device_id: device0
     # Restarts the BMS
     restart:
-      name: "${bms0} restart"
+      name: "restart"
       device_id: device0
     # Shuts down the BMS
     shutdown:
-      name: "${bms0} shutdown"
+      name: "shutdown"
       device_id: device0
     # Resets the BMS to the factory settings
     factory_reset:
-      name: "${bms0} factory reset"
+      name: "factory reset"
       device_id: device0
     # Resets the BMS current to zero
     reset_current:
-      name: "${bms0} reset current"
+      name: "reset current"
       device_id: device0
 
   - platform: daly_bms_ble
     daly_bms_ble_id: bms1
     retrieve_settings:
-      name: "${bms1} retrieve settings"
+      name: "retrieve settings"
       device_id: device1
     restart:
-      name: "${bms1} restart"
+      name: "restart"
       device_id: device1
     shutdown:
-      name: "${bms1} shutdown"
+      name: "shutdown"
       device_id: device1
     factory_reset:
-      name: "${bms1} factory reset"
+      name: "factory reset"
       device_id: device1
     reset_current:
-      name: "${bms1} reset current"
+      name: "reset current"
       device_id: device1
 
 sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     error_bitmask:
-      name: "${bms0} error bitmask"
+      name: "error bitmask"
       device_id: device0
     total_voltage:
-      name: "${bms0} total voltage"
+      name: "total voltage"
       device_id: device0
     current:
-      name: "${bms0} current"
+      name: "current"
       device_id: device0
     power:
-      name: "${bms0} power"
+      name: "power"
       device_id: device0
     charging_power:
-      name: "${bms0} charging power"
+      name: "charging power"
       device_id: device0
     discharging_power:
-      name: "${bms0} discharging power"
+      name: "discharging power"
       device_id: device0
     state_of_charge:
-      name: "${bms0} state of charge"
+      name: "state of charge"
       device_id: device0
     charging_cycles:
-      name: "${bms0} charging cycles"
+      name: "charging cycles"
       device_id: device0
     min_cell_voltage:
-      name: "${bms0} min cell voltage"
+      name: "min cell voltage"
       device_id: device0
     max_cell_voltage:
-      name: "${bms0} max cell voltage"
+      name: "max cell voltage"
       device_id: device0
     min_voltage_cell:
-      name: "${bms0} min voltage cell"
+      name: "min voltage cell"
       device_id: device0
     max_voltage_cell:
-      name: "${bms0} max voltage cell"
+      name: "max voltage cell"
       device_id: device0
     delta_cell_voltage:
-      name: "${bms0} delta cell voltage"
+      name: "delta cell voltage"
       device_id: device0
     average_cell_voltage:
-      name: "${bms0} average cell voltage"
+      name: "average cell voltage"
       device_id: device0
     temperature_1:
-      name: "${bms0} temperature 1"
+      name: "temperature 1"
       device_id: device0
     temperature_2:
-      name: "${bms0} temperature 2"
+      name: "temperature 2"
       device_id: device0
     temperature_3:
-      name: "${bms0} temperature 3"
+      name: "temperature 3"
       device_id: device0
     temperature_4:
-      name: "${bms0} temperature 4"
+      name: "temperature 4"
       device_id: device0
     temperature_5:
-      name: "${bms0} temperature 5"
+      name: "temperature 5"
       device_id: device0
     temperature_6:
-      name: "${bms0} temperature 6"
+      name: "temperature 6"
       device_id: device0
     temperature_7:
-      name: "${bms0} temperature 7"
+      name: "temperature 7"
       device_id: device0
     temperature_8:
-      name: "${bms0} temperature 8"
+      name: "temperature 8"
       device_id: device0
     cell_voltage_1:
-      name: "${bms0} cell voltage 1"
+      name: "cell voltage 1"
       device_id: device0
     cell_voltage_2:
-      name: "${bms0} cell voltage 2"
+      name: "cell voltage 2"
       device_id: device0
     cell_voltage_3:
-      name: "${bms0} cell voltage 3"
+      name: "cell voltage 3"
       device_id: device0
     cell_voltage_4:
-      name: "${bms0} cell voltage 4"
+      name: "cell voltage 4"
       device_id: device0
     cell_voltage_5:
-      name: "${bms0} cell voltage 5"
+      name: "cell voltage 5"
       device_id: device0
     cell_voltage_6:
-      name: "${bms0} cell voltage 6"
+      name: "cell voltage 6"
       device_id: device0
     cell_voltage_7:
-      name: "${bms0} cell voltage 7"
+      name: "cell voltage 7"
       device_id: device0
     cell_voltage_8:
-      name: "${bms0} cell voltage 8"
+      name: "cell voltage 8"
       device_id: device0
     cell_voltage_9:
-      name: "${bms0} cell voltage 9"
+      name: "cell voltage 9"
       device_id: device0
     cell_voltage_10:
-      name: "${bms0} cell voltage 10"
+      name: "cell voltage 10"
       device_id: device0
     cell_voltage_11:
-      name: "${bms0} cell voltage 11"
+      name: "cell voltage 11"
       device_id: device0
     cell_voltage_12:
-      name: "${bms0} cell voltage 12"
+      name: "cell voltage 12"
       device_id: device0
     cell_voltage_13:
-      name: "${bms0} cell voltage 13"
+      name: "cell voltage 13"
       device_id: device0
     cell_voltage_14:
-      name: "${bms0} cell voltage 14"
+      name: "cell voltage 14"
       device_id: device0
     cell_voltage_15:
-      name: "${bms0} cell voltage 15"
+      name: "cell voltage 15"
       device_id: device0
     cell_voltage_16:
-      name: "${bms0} cell voltage 16"
+      name: "cell voltage 16"
       device_id: device0
     cell_voltage_17:
-      name: "${bms0} cell voltage 17"
+      name: "cell voltage 17"
       device_id: device0
     cell_voltage_18:
-      name: "${bms0} cell voltage 18"
+      name: "cell voltage 18"
       device_id: device0
     cell_voltage_19:
-      name: "${bms0} cell voltage 19"
+      name: "cell voltage 19"
       device_id: device0
     cell_voltage_20:
-      name: "${bms0} cell voltage 20"
+      name: "cell voltage 20"
       device_id: device0
     cell_voltage_21:
-      name: "${bms0} cell voltage 21"
+      name: "cell voltage 21"
       device_id: device0
     cell_voltage_22:
-      name: "${bms0} cell voltage 22"
+      name: "cell voltage 22"
       device_id: device0
     cell_voltage_23:
-      name: "${bms0} cell voltage 23"
+      name: "cell voltage 23"
       device_id: device0
     cell_voltage_24:
-      name: "${bms0} cell voltage 24"
+      name: "cell voltage 24"
       device_id: device0
     cell_voltage_25:
-      name: "${bms0} cell voltage 25"
+      name: "cell voltage 25"
       device_id: device0
     cell_voltage_26:
-      name: "${bms0} cell voltage 26"
+      name: "cell voltage 26"
       device_id: device0
     cell_voltage_27:
-      name: "${bms0} cell voltage 27"
+      name: "cell voltage 27"
       device_id: device0
     cell_voltage_28:
-      name: "${bms0} cell voltage 28"
+      name: "cell voltage 28"
       device_id: device0
     cell_voltage_29:
-      name: "${bms0} cell voltage 29"
+      name: "cell voltage 29"
       device_id: device0
     cell_voltage_30:
-      name: "${bms0} cell voltage 30"
+      name: "cell voltage 30"
       device_id: device0
     cell_voltage_31:
-      name: "${bms0} cell voltage 31"
+      name: "cell voltage 31"
       device_id: device0
     cell_voltage_32:
-      name: "${bms0} cell voltage 32"
+      name: "cell voltage 32"
       device_id: device0
     cell_count:
-      name: "${bms0} cell count"
+      name: "cell count"
       device_id: device0
     temperature_sensors:
-      name: "${bms0} temperature sensors"
+      name: "temperature sensors"
       device_id: device0
     capacity_remaining:
-      name: "${bms0} capacity remaining"
+      name: "capacity remaining"
       device_id: device0
 
   - platform: daly_bms_ble
     daly_bms_ble_id: bms1
     error_bitmask:
-      name: "${bms1} error bitmask"
+      name: "error bitmask"
       device_id: device1
     total_voltage:
-      name: "${bms1} total voltage"
+      name: "total voltage"
       device_id: device1
     current:
-      name: "${bms1} current"
+      name: "current"
       device_id: device1
     power:
-      name: "${bms1} power"
+      name: "power"
       device_id: device1
     charging_power:
-      name: "${bms1} charging power"
+      name: "charging power"
       device_id: device1
     discharging_power:
-      name: "${bms1} discharging power"
+      name: "discharging power"
       device_id: device1
     state_of_charge:
-      name: "${bms1} state of charge"
+      name: "state of charge"
       device_id: device1
     charging_cycles:
-      name: "${bms1} charging cycles"
+      name: "charging cycles"
       device_id: device1
     min_cell_voltage:
-      name: "${bms1} min cell voltage"
+      name: "min cell voltage"
       device_id: device1
     max_cell_voltage:
-      name: "${bms1} max cell voltage"
+      name: "max cell voltage"
       device_id: device1
     min_voltage_cell:
-      name: "${bms1} min voltage cell"
+      name: "min voltage cell"
       device_id: device1
     max_voltage_cell:
-      name: "${bms1} max voltage cell"
+      name: "max voltage cell"
       device_id: device1
     delta_cell_voltage:
-      name: "${bms1} delta cell voltage"
+      name: "delta cell voltage"
       device_id: device1
     average_cell_voltage:
-      name: "${bms1} average cell voltage"
+      name: "average cell voltage"
       device_id: device1
     temperature_1:
-      name: "${bms1} temperature 1"
+      name: "temperature 1"
       device_id: device1
     temperature_2:
-      name: "${bms1} temperature 2"
+      name: "temperature 2"
       device_id: device1
     temperature_3:
-      name: "${bms1} temperature 3"
+      name: "temperature 3"
       device_id: device1
     temperature_4:
-      name: "${bms1} temperature 4"
+      name: "temperature 4"
       device_id: device1
     temperature_5:
-      name: "${bms1} temperature 5"
+      name: "temperature 5"
       device_id: device1
     temperature_6:
-      name: "${bms1} temperature 6"
+      name: "temperature 6"
       device_id: device1
     temperature_7:
-      name: "${bms1} temperature 7"
+      name: "temperature 7"
       device_id: device1
     temperature_8:
-      name: "${bms1} temperature 8"
+      name: "temperature 8"
       device_id: device1
     cell_voltage_1:
-      name: "${bms1} cell voltage 1"
+      name: "cell voltage 1"
       device_id: device1
     cell_voltage_2:
-      name: "${bms1} cell voltage 2"
+      name: "cell voltage 2"
       device_id: device1
     cell_voltage_3:
-      name: "${bms1} cell voltage 3"
+      name: "cell voltage 3"
       device_id: device1
     cell_voltage_4:
-      name: "${bms1} cell voltage 4"
+      name: "cell voltage 4"
       device_id: device1
     cell_voltage_5:
-      name: "${bms1} cell voltage 5"
+      name: "cell voltage 5"
       device_id: device1
     cell_voltage_6:
-      name: "${bms1} cell voltage 6"
+      name: "cell voltage 6"
       device_id: device1
     cell_voltage_7:
-      name: "${bms1} cell voltage 7"
+      name: "cell voltage 7"
       device_id: device1
     cell_voltage_8:
-      name: "${bms1} cell voltage 8"
+      name: "cell voltage 8"
       device_id: device1
     cell_voltage_9:
-      name: "${bms1} cell voltage 9"
+      name: "cell voltage 9"
       device_id: device1
     cell_voltage_10:
-      name: "${bms1} cell voltage 10"
+      name: "cell voltage 10"
       device_id: device1
     cell_voltage_11:
-      name: "${bms1} cell voltage 11"
+      name: "cell voltage 11"
       device_id: device1
     cell_voltage_12:
-      name: "${bms1} cell voltage 12"
+      name: "cell voltage 12"
       device_id: device1
     cell_voltage_13:
-      name: "${bms1} cell voltage 13"
+      name: "cell voltage 13"
       device_id: device1
     cell_voltage_14:
-      name: "${bms1} cell voltage 14"
+      name: "cell voltage 14"
       device_id: device1
     cell_voltage_15:
-      name: "${bms1} cell voltage 15"
+      name: "cell voltage 15"
       device_id: device1
     cell_voltage_16:
-      name: "${bms1} cell voltage 16"
+      name: "cell voltage 16"
       device_id: device1
     cell_voltage_17:
-      name: "${bms1} cell voltage 17"
+      name: "cell voltage 17"
       device_id: device1
     cell_voltage_18:
-      name: "${bms1} cell voltage 18"
+      name: "cell voltage 18"
       device_id: device1
     cell_voltage_19:
-      name: "${bms1} cell voltage 19"
+      name: "cell voltage 19"
       device_id: device1
     cell_voltage_20:
-      name: "${bms1} cell voltage 20"
+      name: "cell voltage 20"
       device_id: device1
     cell_voltage_21:
-      name: "${bms1} cell voltage 21"
+      name: "cell voltage 21"
       device_id: device1
     cell_voltage_22:
-      name: "${bms1} cell voltage 22"
+      name: "cell voltage 22"
       device_id: device1
     cell_voltage_23:
-      name: "${bms1} cell voltage 23"
+      name: "cell voltage 23"
       device_id: device1
     cell_voltage_24:
-      name: "${bms1} cell voltage 24"
+      name: "cell voltage 24"
       device_id: device1
     cell_voltage_25:
-      name: "${bms1} cell voltage 25"
+      name: "cell voltage 25"
       device_id: device1
     cell_voltage_26:
-      name: "${bms1} cell voltage 26"
+      name: "cell voltage 26"
       device_id: device1
     cell_voltage_27:
-      name: "${bms1} cell voltage 27"
+      name: "cell voltage 27"
       device_id: device1
     cell_voltage_28:
-      name: "${bms1} cell voltage 28"
+      name: "cell voltage 28"
       device_id: device1
     cell_voltage_29:
-      name: "${bms1} cell voltage 29"
+      name: "cell voltage 29"
       device_id: device1
     cell_voltage_30:
-      name: "${bms1} cell voltage 30"
+      name: "cell voltage 30"
       device_id: device1
     cell_voltage_31:
-      name: "${bms1} cell voltage 31"
+      name: "cell voltage 31"
       device_id: device1
     cell_voltage_32:
-      name: "${bms1} cell voltage 32"
+      name: "cell voltage 32"
       device_id: device1
     cell_count:
-      name: "${bms1} cell count"
+      name: "cell count"
       device_id: device1
     temperature_sensors:
-      name: "${bms1} temperature sensors"
+      name: "temperature sensors"
       device_id: device1
     capacity_remaining:
-      name: "${bms1} capacity remaining"
+      name: "capacity remaining"
       device_id: device1
 
 switch:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     balancer:
-      name: "${bms0} balancer"
+      name: "balancer"
       device_id: device0
     charging:
-      name: "${bms0} charging"
+      name: "charging"
       device_id: device0
     discharging:
-      name: "${bms0} discharging"
+      name: "discharging"
       device_id: device0
 
   - platform: daly_bms_ble
     daly_bms_ble_id: bms1
     balancer:
-      name: "${bms1} balancer"
+      name: "balancer"
       device_id: device1
     charging:
-      name: "${bms1} charging"
+      name: "charging"
       device_id: device1
     discharging:
-      name: "${bms1} discharging"
+      name: "discharging"
       device_id: device1
 
   - platform: ble_client
     ble_client_id: client0
-    name: "${bms0} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch0
     device_id: device0
 
   - platform: ble_client
     ble_client_id: client1
-    name: "${bms1} enable bluetooth connection"
+    name: "enable bluetooth connection"
     id: ble_client_switch1
     device_id: device1
 
@@ -534,17 +534,17 @@ text_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
     battery_status:
-      name: "${bms0} battery status"
+      name: "battery status"
       device_id: device0
     errors:
-      name: "${bms0} errors"
+      name: "errors"
       device_id: device0
 
   - platform: daly_bms_ble
     daly_bms_ble_id: bms1
     battery_status:
-      name: "${bms1} battery status"
+      name: "battery status"
       device_id: device1
     errors:
-      name: "${bms1} errors"
+      name: "errors"
       device_id: device1


### PR DESCRIPTION
Use ESPHome sub-devices feature: entity names no longer need the device name prefix since the sub-device name is automatically prepended by Home Assistant via `has_entity_name = True` semantics.

- Remove `${bms0}`/`${bms1}` prefix from all entity `name:` fields in `*multiple-devices*.yaml`
- Add `devices:` block and `device_id:` per entity where missing (jbd-bms, tianpower-bms)
- Add `device_id:` to `ble_client` switches where missing (lolan-bms, jk-bms)