### PR TITLE
Replace static const char arrays with constexpr

### DIFF
--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -35,7 +35,7 @@ static const uint8_t DALY_FRAME_LEN_PASSWORD = 6;
 static const uint8_t MAX_RESPONSE_SIZE = 165;
 
 static const uint8_t ERRORS_SIZE = 64;
-static const char *const ERRORS[ERRORS_SIZE] = {
+static constexpr const char *const ERRORS[ERRORS_SIZE] = {
     // Register 0x3D, Byte 0
     // Reserved but unused
     "",


### PR DESCRIPTION
## Summary

- Replace `static const char *const ERRORS[ERRORS_SIZE]` with `static constexpr const char *const ERRORS[ERRORS_SIZE]` in `components/daly_bms_ble/daly_bms_ble.cpp`

## Why

Using `static constexpr const char *const` for string arrays ensures the data is placed into the read-only segment (Flash) at compile time instead of occupying RAM at runtime. This is the established style in the ESPHome core (see e.g. `bme68x_bsec2.cpp`) and is important for microcontroller targets where RAM is a scarce resource.