### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/daly_bms_ble/button/daly_button.cpp
+++ b/components/daly_bms_ble/button/daly_button.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 static const char *const TAG = "daly_bms_ble.button";
 
@@ -23,5 +22,4 @@ void DalyButton::press_action() {
   this->parent_->send_command(DALY_FUNCTION_WRITE, this->holding_register_, 0x0001);
 }
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/button/daly_button.h
+++ b/components/daly_bms_ble/button/daly_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 class DalyBmsBle;
 class DalyButton : public button::Button, public Component {
@@ -22,5 +21,4 @@ class DalyButton : public button::Button, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 static const char *const TAG = "daly_bms_ble";
 
@@ -774,5 +773,4 @@ std::string DalyBmsBle::bitmask_to_string_(const char *const messages[], const u
   return values;
 }
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/daly_bms_ble.h
+++ b/components/daly_bms_ble/daly_bms_ble.h
@@ -13,8 +13,7 @@
 #include <esp_gattc_api.h>
 #endif
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 #ifdef USE_ESP32
 namespace espbt = esphome::esp32_ble_tracker;
@@ -182,5 +181,4 @@ class DalyBmsBle :
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/number/daly_number.cpp
+++ b/components/daly_bms_ble/number/daly_number.cpp
@@ -1,8 +1,7 @@
 #include "daly_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 static const char *const TAG = "daly_bms_ble.number";
 
@@ -13,5 +12,4 @@ void DalyNumber::control(float value) {
   }
 }
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/number/daly_number.h
+++ b/components/daly_bms_ble/number/daly_number.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 class DalyBmsBle;
 class DalyNumber : public number::Number, public Component {
@@ -22,5 +21,4 @@ class DalyNumber : public number::Number, public Component {
   float factor_{1.0f};
 };
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/switch/daly_switch.cpp
+++ b/components/daly_bms_ble/switch/daly_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 static const char *const TAG = "daly_bms_ble.switch";
 
@@ -16,5 +15,4 @@ void DalySwitch::write_state(bool state) {
   }
 }
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/switch/daly_switch.h
+++ b/components/daly_bms_ble/switch/daly_switch.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace daly_bms_ble {
+namespace esphome::daly_bms_ble {
 
 class DalyBmsBle;
 class DalySwitch : public switch_::Switch, public Component {
@@ -22,5 +21,4 @@ class DalySwitch : public switch_::Switch, public Component {
   uint16_t holding_register_;
 };
 
-}  // namespace daly_bms_ble
-}  // namespace esphome
+}  // namespace esphome::daly_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.