### PR TITLE
Fix redundant string initialization

### DIFF
--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -758,7 +758,7 @@ void DalyBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std:
 
 std::string DalyBmsBle::bitmask_to_string_(const char *const messages[], const uint8_t &messages_size,
                                            const uint64_t &mask) {
-  std::string values = "";
+  std::string values;
   if (mask) {
     for (uint8_t i = 0; i < messages_size; i++) {
       if (mask & (1ULL << i)) {


### PR DESCRIPTION
Remove redundant empty string initialization (`= ""`) flagged by `readability-redundant-string-init`. `std::string` default-constructs to an empty string.