### PR TITLE
Add button to retrieve version details

### DIFF
--- a/components/daly_bms_ble/button/__init__.py
+++ b/components/daly_bms_ble/button/__init__.py
@@ -10,21 +10,28 @@ DEPENDENCIES = ["daly_bms_ble"]
 CODEOWNERS = ["@syssi"]
 
 CONF_RETRIEVE_SETTINGS = "retrieve_settings"
+CONF_RETRIEVE_VERSION = "retrieve_version"
 CONF_SHUTDOWN = "shutdown"
 CONF_RESET_CURRENT = "reset_current"
 
+DALY_FUNCTION_READ = 0x03
+DALY_FUNCTION_WRITE = 0x06
+
 ICON_RETRIEVE_SETTINGS = "mdi:cog"
+ICON_RETRIEVE_VERSION = "mdi:information"
 ICON_RESTART = "mdi:restart"
 ICON_SHUTDOWN = "mdi:power"
 ICON_RESET_CURRENT = "mdi:counter"
 ICON_FACTORY_RESET = "mdi:factory"
 
+# (function, address, value)
 BUTTONS = {
-    CONF_RETRIEVE_SETTINGS: 0x0080,
-    CONF_RESTART: 0x00F0,
-    CONF_SHUTDOWN: 0x00F1,
-    CONF_RESET_CURRENT: 0x00F2,
-    CONF_FACTORY_RESET: 0x00F3,
+    CONF_RETRIEVE_SETTINGS: (DALY_FUNCTION_READ, 0x0080, 0x0029),
+    CONF_RETRIEVE_VERSION: (DALY_FUNCTION_READ, 0x00A9, 0x0020),
+    CONF_RESTART: (DALY_FUNCTION_WRITE, 0x00F0, 0x0001),
+    CONF_SHUTDOWN: (DALY_FUNCTION_WRITE, 0x00F1, 0x0001),
+    CONF_RESET_CURRENT: (DALY_FUNCTION_WRITE, 0x00F2, 0x0001),
+    CONF_FACTORY_RESET: (DALY_FUNCTION_WRITE, 0x00F3, 0x0001),
 }
 
 DalyButton = daly_bms_ble_ns.class_("DalyButton", button.Button, cg.Component)
@@ -33,6 +40,9 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_RETRIEVE_SETTINGS): button.button_schema(
             DalyButton, icon=ICON_RETRIEVE_SETTINGS
+        ),
+        cv.Optional(CONF_RETRIEVE_VERSION): button.button_schema(
+            DalyButton, icon=ICON_RETRIEVE_VERSION
         ),
         cv.Optional(CONF_RESTART): button.button_schema(
             DalyButton, icon=ICON_RESTART, device_class=DEVICE_CLASS_RESTART
@@ -52,10 +62,12 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_DALY_BMS_BLE_ID])
-    for key, address in BUTTONS.items():
+    for key, (function, address, value) in BUTTONS.items():
         if key in config:
             conf = config[key]
             var = await button.new_button(conf)
             await cg.register_component(var, conf)
             cg.add(var.set_parent(hub))
+            cg.add(var.set_function(function))
             cg.add(var.set_holding_register(address))
+            cg.add(var.set_value(value))

--- a/components/daly_bms_ble/button/__init__.py
+++ b/components/daly_bms_ble/button/__init__.py
@@ -14,15 +14,15 @@ CONF_RETRIEVE_VERSION = "retrieve_version"
 CONF_SHUTDOWN = "shutdown"
 CONF_RESET_CURRENT = "reset_current"
 
-DALY_FUNCTION_READ = 0x03
-DALY_FUNCTION_WRITE = 0x06
-
 ICON_RETRIEVE_SETTINGS = "mdi:cog"
 ICON_RETRIEVE_VERSION = "mdi:information"
 ICON_RESTART = "mdi:restart"
 ICON_SHUTDOWN = "mdi:power"
 ICON_RESET_CURRENT = "mdi:counter"
 ICON_FACTORY_RESET = "mdi:factory"
+
+DALY_FUNCTION_READ = 0x03
+DALY_FUNCTION_WRITE = 0x06
 
 # (function, address, value)
 BUTTONS = {

--- a/components/daly_bms_ble/button/daly_button.cpp
+++ b/components/daly_bms_ble/button/daly_button.cpp
@@ -6,20 +6,7 @@ namespace esphome::daly_bms_ble {
 
 static const char *const TAG = "daly_bms_ble.button";
 
-static const uint8_t DALY_FUNCTION_READ = 0x03;
-static const uint8_t DALY_FUNCTION_WRITE = 0x06;
-
-static const uint16_t DALY_COMMAND_REQ_SETTINGS_START = 0x0080;
-static const uint16_t DALY_COMMAND_REQ_SETTINGS_QTY = 0x0029;
-
 void DalyButton::dump_config() { LOG_BUTTON("", "DalyBmsBle Button", this); }
-void DalyButton::press_action() {
-  if (this->holding_register_ == DALY_COMMAND_REQ_SETTINGS_START) {
-    this->parent_->send_command(DALY_FUNCTION_READ, this->holding_register_, DALY_COMMAND_REQ_SETTINGS_QTY);
-    return;
-  }
-
-  this->parent_->send_command(DALY_FUNCTION_WRITE, this->holding_register_, 0x0001);
-}
+void DalyButton::press_action() { this->parent_->send_command(this->function_, this->holding_register_, this->value_); }
 
 }  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/button/daly_button.h
+++ b/components/daly_bms_ble/button/daly_button.h
@@ -10,7 +10,9 @@ class DalyBmsBle;
 class DalyButton : public button::Button, public Component {
  public:
   void set_parent(DalyBmsBle *parent) { this->parent_ = parent; };
+  void set_function(uint8_t function) { this->function_ = function; };
   void set_holding_register(uint16_t holding_register) { this->holding_register_ = holding_register; };
+  void set_value(uint16_t value) { this->value_ = value; };
   void dump_config() override;
   void loop() override {}
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -18,7 +20,9 @@ class DalyButton : public button::Button, public Component {
  protected:
   void press_action() override;
   DalyBmsBle *parent_;
-  uint16_t holding_register_;
+  uint8_t function_{0};
+  uint16_t holding_register_{0};
+  uint16_t value_{0};
 };
 
 }  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -620,13 +620,19 @@ void DalyBmsBle::decode_version_data_(const std::vector<uint8_t> &data) {
   //          0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //          0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //          0x00 0x00            Software version
-  ESP_LOGI(TAG, "Software version: %s", std::string(data.begin() + 3, data.begin() + 3 + 32).c_str());
+  auto sw_begin = data.begin() + 3;
+  auto software_version = std::string(sw_begin, std::find(sw_begin, sw_begin + 32, '\0'));
+  ESP_LOGI(TAG, "Software version: %s", software_version.c_str());
+  this->publish_state_(this->software_version_text_sensor_, software_version);
 
   //  35  32  0x42 0x4D 0x53 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //          0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //          0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
   //          0x00 0x00            Hardware version
-  ESP_LOGI(TAG, "Hardware version: %s", std::string(data.begin() + 35, data.begin() + 35 + 32).c_str());
+  auto hw_begin = data.begin() + 35;
+  auto hardware_version = std::string(hw_begin, std::find(hw_begin, hw_begin + 32, '\0'));
+  ESP_LOGI(TAG, "Hardware version: %s", hardware_version.c_str());
+  this->publish_state_(this->hardware_version_text_sensor_, hardware_version);
 
   //  67   2  0x65 0x13            CRC
 }
@@ -719,6 +725,8 @@ void DalyBmsBle::dump_config() {  // NOLINT(google-readability-function-size,rea
 
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
   LOG_TEXT_SENSOR("", "Battery Status", this->battery_status_text_sensor_);
+  LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
+  LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
 }
 
 void DalyBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {

--- a/components/daly_bms_ble/daly_bms_ble.h
+++ b/components/daly_bms_ble/daly_bms_ble.h
@@ -100,6 +100,12 @@ class DalyBmsBle :
     battery_status_text_sensor_ = battery_status_text_sensor;
   }
   void set_errors_text_sensor(text_sensor::TextSensor *errors_text_sensor) { errors_text_sensor_ = errors_text_sensor; }
+  void set_software_version_text_sensor(text_sensor::TextSensor *software_version_text_sensor) {
+    software_version_text_sensor_ = software_version_text_sensor;
+  }
+  void set_hardware_version_text_sensor(text_sensor::TextSensor *hardware_version_text_sensor) {
+    hardware_version_text_sensor_ = hardware_version_text_sensor;
+  }
 
   void set_balancer_switch(switch_::Switch *balancer_switch) { balancer_switch_ = balancer_switch; }
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
@@ -151,6 +157,8 @@ class DalyBmsBle :
 
   text_sensor::TextSensor *battery_status_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};
+  text_sensor::TextSensor *software_version_text_sensor_{nullptr};
+  text_sensor::TextSensor *hardware_version_text_sensor_{nullptr};
 
   struct Cell {
     sensor::Sensor *cell_voltage_sensor_{nullptr};

--- a/components/daly_bms_ble/text_sensor.py
+++ b/components/daly_bms_ble/text_sensor.py
@@ -11,13 +11,19 @@ CODEOWNERS = ["@syssi"]
 
 CONF_BATTERY_STATUS = "battery_status"
 CONF_ERRORS = "errors"
+CONF_SOFTWARE_VERSION = "software_version"
+CONF_HARDWARE_VERSION = "hardware_version"
 
 ICON_BATTERY_STATUS = "mdi:battery-charging"
 ICON_ERRORS = "mdi:alert-circle-outline"
+ICON_SOFTWARE_VERSION = "mdi:tag"
+ICON_HARDWARE_VERSION = "mdi:tag"
 
 TEXT_SENSORS = [
     CONF_BATTERY_STATUS,
     CONF_ERRORS,
+    CONF_SOFTWARE_VERSION,
+    CONF_HARDWARE_VERSION,
 ]
 
 CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
@@ -27,6 +33,14 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
         ),
         cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
             icon=ICON_ERRORS,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
+            icon=ICON_SOFTWARE_VERSION,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_HARDWARE_VERSION): text_sensor.text_sensor_schema(
+            icon=ICON_HARDWARE_VERSION,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     }

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -76,6 +76,9 @@ button:
     # Retrieves the BMS settings and prints them in the ESPHome logs
     retrieve_settings:
       name: "retrieve settings"
+    # Retrieves the BMS software/hardware version and publishes it to the text sensors
+    retrieve_version:
+      name: "retrieve version"
     # Restarts the BMS
     restart:
       name: "restart"
@@ -241,3 +244,7 @@ text_sensor:
       name: "battery status"
     errors:
       name: "errors"
+    software_version:
+      name: "software version"
+    hardware_version:
+      name: "hardware version"

--- a/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
+++ b/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
@@ -10,6 +10,46 @@ TEST(DalyBmsBleVersionTest, NullSensorsDoNotCrash) {
   bms.decode_version_data_(VERSION_FRAME_1);
 }
 
+TEST(DalyBmsBleVersionTest, SoftwareVersion) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor sw_version;
+  bms.set_software_version_text_sensor(&sw_version);
+
+  bms.decode_version_data_(VERSION_FRAME_1);
+
+  EXPECT_EQ(sw_version.state, "401012");
+}
+
+TEST(DalyBmsBleVersionTest, HardwareVersion) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor hw_version;
+  bms.set_hardware_version_text_sensor(&hw_version);
+
+  bms.decode_version_data_(VERSION_FRAME_1);
+
+  EXPECT_EQ(hw_version.state, "BMS");
+}
+
+TEST(DalyBmsBleVersionTest, SoftwareVersionFrame2) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor sw_version;
+  bms.set_software_version_text_sensor(&sw_version);
+
+  bms.decode_version_data_(VERSION_FRAME_2);
+
+  EXPECT_EQ(sw_version.state, "204012");
+}
+
+TEST(DalyBmsBleVersionTest, HardwareVersionFrame2) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor hw_version;
+  bms.set_hardware_version_text_sensor(&hw_version);
+
+  bms.decode_version_data_(VERSION_FRAME_2);
+
+  EXPECT_EQ(hw_version.state, "SH39F003");
+}
+
 TEST(DalyBmsBleVersionTest, DispatchedViaOnData) {
   TestableDalyBmsBle bms;
   bms.on_daly_bms_ble_data(VERSION_FRAME_1);

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -74,13 +74,14 @@ class TestButtonConstants:
         from esphome.const import CONF_FACTORY_RESET, CONF_RESTART
 
         assert button.CONF_RETRIEVE_SETTINGS in button.BUTTONS
+        assert button.CONF_RETRIEVE_VERSION in button.BUTTONS
         assert CONF_RESTART in button.BUTTONS
         assert button.CONF_SHUTDOWN in button.BUTTONS
         assert button.CONF_RESET_CURRENT in button.BUTTONS
         assert CONF_FACTORY_RESET in button.BUTTONS
 
     def test_button_addresses_are_unique(self):
-        addresses = list(button.BUTTONS.values())
+        addresses = [address for _, address, _ in button.BUTTONS.values()]
         assert len(addresses) == len(set(addresses))
 
 
@@ -100,3 +101,5 @@ class TestTextSensorConstants:
     def test_text_sensors_list(self):
         assert text_sensor.CONF_BATTERY_STATUS in text_sensor.TEXT_SENSORS
         assert text_sensor.CONF_ERRORS in text_sensor.TEXT_SENSORS
+        assert text_sensor.CONF_SOFTWARE_VERSION in text_sensor.TEXT_SENSORS
+        assert text_sensor.CONF_HARDWARE_VERSION in text_sensor.TEXT_SENSORS


### PR DESCRIPTION
## Summary

Implements #19.

- Adds a `retrieve_version` button that triggers a Modbus read of registers `0x00A9`–`0x00C8` (32 registers, 64 bytes), which the BMS responds to with its software/hardware version frame.
- Adds `software_version` and `hardware_version` text sensors that are populated when the version response arrives. Null bytes are stripped before publishing.
- Extends the example YAML with the new button and text sensors.
- Adds C++ unit tests that assert the decoded version strings and Python schema tests for the new constants.

## Test plan

- [ ] Python schema tests: `pytest tests/test_component_schemas.py -v`
- [ ] C++ unit tests: `script/cpp_unit_test.py daly_bms_ble`
- [ ] On hardware: press **retrieve version**, verify `software_version` and `hardware_version` entities update in Home Assistant / ESPHome logs