### PR TITLE
Add 39 number entities for BMS settings

### DIFF
--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -598,12 +598,16 @@ void DalyBmsBle::decode_settings_data_(const std::vector<uint8_t> &data) {
 
   //  81   2  0x02 0xA8   0xA7    SOC settings (68.0)                                     %          0.1
   ESP_LOGI(TAG, "SOC settings: %.1f %%", daly_get_16bit(81) * 0.1f);
-  this->publish_state_(this->state_of_charge_setting_number_, daly_get_16bit(81) * 0.1f);
 
   //  83   2  0x00 0x57   0xA8    MOS temperature protection alarm (7)                    °C         1
   ESP_LOGI(TAG, "MOS temperature protection alarm: %d °C", daly_get_16bit(83) - 40);
 
   //  85   2  0x7F 0x8B   CRC
+
+  for (auto &[address, sn] : this->settings_numbers_) {
+    uint16_t raw = daly_get_16bit(3 + (address - 0x0080) * 2);
+    this->publish_state_(sn.number, (raw - sn.offset) / sn.factor);
+  }
 }
 
 void DalyBmsBle::decode_version_data_(const std::vector<uint8_t> &data) {
@@ -720,8 +724,6 @@ void DalyBmsBle::dump_config() {  // NOLINT(google-readability-function-size,rea
   LOG_SENSOR("", "Balance current", this->balance_current_sensor_);
   LOG_SENSOR("", "Mosfet temperature", this->mosfet_temperature_sensor_);
   LOG_SENSOR("", "Board temperature", this->board_temperature_sensor_);
-
-  LOG_NUMBER("", "State of charge setting", this->state_of_charge_setting_number_);
 
   LOG_TEXT_SENSOR("", "Errors", this->errors_text_sensor_);
   LOG_TEXT_SENSOR("", "Battery Status", this->battery_status_text_sensor_);

--- a/components/daly_bms_ble/daly_bms_ble.h
+++ b/components/daly_bms_ble/daly_bms_ble.h
@@ -6,6 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include <map>
 
 #ifdef USE_ESP32
 #include "esphome/components/ble_client/ble_client.h"
@@ -111,7 +112,9 @@ class DalyBmsBle :
   void set_charging_switch(switch_::Switch *charging_switch) { charging_switch_ = charging_switch; }
   void set_discharging_switch(switch_::Switch *discharging_switch) { discharging_switch_ = discharging_switch; }
 
-  void set_state_of_charge_setting_number(number::Number *number) { state_of_charge_setting_number_ = number; }
+  void register_settings_number(uint16_t address, number::Number *number, float factor, float offset) {
+    this->settings_numbers_[address] = {number, factor, offset};
+  }
 #ifdef USE_ESP32
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
@@ -153,7 +156,12 @@ class DalyBmsBle :
   switch_::Switch *charging_switch_{nullptr};
   switch_::Switch *discharging_switch_{nullptr};
 
-  number::Number *state_of_charge_setting_number_{nullptr};
+  struct SettingsNumber {
+    number::Number *number;
+    float factor;
+    float offset;
+  };
+  std::map<uint16_t, SettingsNumber> settings_numbers_;
 
   text_sensor::TextSensor *battery_status_text_sensor_{nullptr};
   text_sensor::TextSensor *errors_text_sensor_{nullptr};

--- a/components/daly_bms_ble/number/__init__.py
+++ b/components/daly_bms_ble/number/__init__.py
@@ -1,7 +1,15 @@
 import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
-from esphome.const import UNIT_PERCENT
+from esphome.const import (
+    ENTITY_CATEGORY_CONFIG,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_EMPTY,
+    UNIT_PERCENT,
+    UNIT_SECOND,
+    UNIT_VOLT,
+)
 
 from .. import CONF_DALY_BMS_BLE_ID, DALY_BMS_BLE_COMPONENT_SCHEMA, daly_bms_ble_ns
 
@@ -9,23 +17,327 @@ DEPENDENCIES = ["daly_bms_ble"]
 
 CODEOWNERS = ["@syssi"]
 
+CONF_ACQUISITION_BOARD_COUNT = "acquisition_board_count"
+CONF_BALANCING_ACTIVATION_VOLTAGE = "balancing_activation_voltage"
+CONF_BALANCING_ACTIVATION_VOLTAGE_DIFFERENCE = "balancing_activation_voltage_difference"
+CONF_BATTERY_TYPE = "battery_type"
+CONF_BOARD_1_CELL_COUNT = "board_1_cell_count"
+CONF_BOARD_1_TEMPERATURE_SENSOR_COUNT = "board_1_temperature_sensor_count"
+CONF_BOARD_2_CELL_COUNT = "board_2_cell_count"
+CONF_BOARD_2_TEMPERATURE_SENSOR_COUNT = "board_2_temperature_sensor_count"
+CONF_BOARD_3_CELL_COUNT = "board_3_cell_count"
+CONF_BOARD_3_TEMPERATURE_SENSOR_COUNT = "board_3_temperature_sensor_count"
+CONF_CELL_OVERVOLTAGE_ALARM = "cell_overvoltage_alarm"
+CONF_CELL_OVERVOLTAGE_WARNING = "cell_overvoltage_warning"
+CONF_CELL_UNDERVOLTAGE_ALARM = "cell_undervoltage_alarm"
+CONF_CELL_UNDERVOLTAGE_WARNING = "cell_undervoltage_warning"
+CONF_CELL_VOLTAGE_DIFFERENCE_ALARM = "cell_voltage_difference_alarm"
+CONF_CELL_VOLTAGE_DIFFERENCE_WARNING = "cell_voltage_difference_warning"
+CONF_CELL_VOLTAGE_REFERENCE = "cell_voltage_reference"
+CONF_CHARGING_OVERCURRENT_ALARM = "charging_overcurrent_alarm"
+CONF_CHARGING_OVERCURRENT_WARNING = "charging_overcurrent_warning"
+CONF_CHARGING_OVERTEMPERATURE_ALARM = "charging_overtemperature_alarm"
+CONF_CHARGING_OVERTEMPERATURE_WARNING = "charging_overtemperature_warning"
+CONF_CHARGING_UNDERTEMPERATURE_ALARM = "charging_undertemperature_alarm"
+CONF_CHARGING_UNDERTEMPERATURE_WARNING = "charging_undertemperature_warning"
+CONF_DISCHARGING_OVERCURRENT_ALARM = "discharging_overcurrent_alarm"
+CONF_DISCHARGING_OVERCURRENT_WARNING = "discharging_overcurrent_warning"
+CONF_DISCHARGING_OVERTEMPERATURE_ALARM = "discharging_overtemperature_alarm"
+CONF_DISCHARGING_OVERTEMPERATURE_WARNING = "discharging_overtemperature_warning"
+CONF_DISCHARGING_UNDERTEMPERATURE_ALARM = "discharging_undertemperature_alarm"
+CONF_DISCHARGING_UNDERTEMPERATURE_WARNING = "discharging_undertemperature_warning"
+CONF_MOSFET_OVERTEMPERATURE_ALARM = "mosfet_overtemperature_alarm"
+CONF_RATED_CAPACITY = "rated_capacity"
+CONF_SLEEP_WAIT_TIME = "sleep_wait_time"
 CONF_STATE_OF_CHARGE_SETTING = "state_of_charge_setting"
-
-ICON_STATE_OF_CHARGE_SETTING = "mdi:battery-sync"
+CONF_TEMPERATURE_DIFFERENCE_ALARM = "temperature_difference_alarm"
+CONF_TEMPERATURE_DIFFERENCE_WARNING = "temperature_difference_warning"
+CONF_TOTAL_OVERVOLTAGE_ALARM = "total_overvoltage_alarm"
+CONF_TOTAL_OVERVOLTAGE_WARNING = "total_overvoltage_warning"
+CONF_TOTAL_UNDERVOLTAGE_ALARM = "total_undervoltage_alarm"
+CONF_TOTAL_UNDERVOLTAGE_WARNING = "total_undervoltage_warning"
 
 DalyNumber = daly_bms_ble_ns.class_("DalyNumber", number.Number, cg.Component)
 
-# key: (register_address, factor, min_value, max_value, step)
+# key: (address, factor, offset, min_value, max_value, step)
 NUMBERS = {
-    CONF_STATE_OF_CHARGE_SETTING: (0x00A7, 10.0, 0.0, 100.0, 0.1),
+    CONF_RATED_CAPACITY: (0x0080, 10.0, 0, 0.0, 6553.5, 0.1),
+    CONF_CELL_VOLTAGE_REFERENCE: (0x0081, 1.0, 0, 0, 65535, 1),
+    CONF_ACQUISITION_BOARD_COUNT: (0x0082, 1.0, 0, 0, 65535, 1),
+    CONF_BOARD_1_CELL_COUNT: (0x0083, 1.0, 0, 0, 65535, 1),
+    CONF_BOARD_2_CELL_COUNT: (0x0084, 1.0, 0, 0, 65535, 1),
+    CONF_BOARD_3_CELL_COUNT: (0x0085, 1.0, 0, 0, 65535, 1),
+    CONF_BOARD_1_TEMPERATURE_SENSOR_COUNT: (0x0086, 1.0, 0, 0, 65535, 1),
+    CONF_BOARD_2_TEMPERATURE_SENSOR_COUNT: (0x0087, 1.0, 0, 0, 65535, 1),
+    CONF_BOARD_3_TEMPERATURE_SENSOR_COUNT: (0x0088, 1.0, 0, 0, 65535, 1),
+    CONF_BATTERY_TYPE: (0x0089, 1.0, 0, 0, 2, 1),
+    CONF_SLEEP_WAIT_TIME: (0x008A, 1.0, 0, 0, 65535, 1),
+    CONF_CELL_OVERVOLTAGE_WARNING: (0x008B, 1.0, 0, 0, 65535, 1),
+    CONF_CELL_OVERVOLTAGE_ALARM: (0x008C, 1.0, 0, 0, 65535, 1),
+    CONF_CELL_UNDERVOLTAGE_WARNING: (0x008D, 1.0, 0, 0, 65535, 1),
+    CONF_CELL_UNDERVOLTAGE_ALARM: (0x008E, 1.0, 0, 0, 65535, 1),
+    CONF_TOTAL_OVERVOLTAGE_WARNING: (0x008F, 10.0, 0, 0, 6553.5, 0.1),
+    CONF_TOTAL_OVERVOLTAGE_ALARM: (0x0090, 10.0, 0, 0, 6553.5, 0.1),
+    CONF_TOTAL_UNDERVOLTAGE_WARNING: (0x0091, 10.0, 0, 0, 6553.5, 0.1),
+    CONF_TOTAL_UNDERVOLTAGE_ALARM: (0x0092, 10.0, 0, 0, 6553.5, 0.1),
+    CONF_CHARGING_OVERCURRENT_WARNING: (0x0093, 10.0, 30000, -3000, 3553.5, 0.1),
+    CONF_CHARGING_OVERCURRENT_ALARM: (0x0094, 10.0, 30000, -3000, 3553.5, 0.1),
+    CONF_DISCHARGING_OVERCURRENT_WARNING: (0x0095, 10.0, 30000, -3000, 3553.5, 0.1),
+    CONF_DISCHARGING_OVERCURRENT_ALARM: (0x0096, 10.0, 30000, -3000, 3553.5, 0.1),
+    CONF_CHARGING_OVERTEMPERATURE_WARNING: (0x0097, 1.0, 40, -40, 100, 1),
+    CONF_CHARGING_OVERTEMPERATURE_ALARM: (0x0098, 1.0, 40, -40, 100, 1),
+    CONF_CHARGING_UNDERTEMPERATURE_WARNING: (0x0099, 1.0, 40, -40, 100, 1),
+    CONF_CHARGING_UNDERTEMPERATURE_ALARM: (0x009A, 1.0, 40, -40, 100, 1),
+    CONF_DISCHARGING_OVERTEMPERATURE_WARNING: (0x009B, 1.0, 40, -40, 100, 1),
+    CONF_DISCHARGING_OVERTEMPERATURE_ALARM: (0x009C, 1.0, 40, -40, 100, 1),
+    CONF_DISCHARGING_UNDERTEMPERATURE_WARNING: (0x009D, 1.0, 40, -40, 100, 1),
+    CONF_DISCHARGING_UNDERTEMPERATURE_ALARM: (0x009E, 1.0, 40, -40, 100, 1),
+    CONF_CELL_VOLTAGE_DIFFERENCE_WARNING: (0x009F, 1.0, 0, 0, 65535, 1),
+    CONF_CELL_VOLTAGE_DIFFERENCE_ALARM: (0x00A0, 1.0, 0, 0, 65535, 1),
+    CONF_TEMPERATURE_DIFFERENCE_WARNING: (0x00A1, 1.0, 0, 0, 65535, 1),
+    CONF_TEMPERATURE_DIFFERENCE_ALARM: (0x00A2, 1.0, 0, 0, 65535, 1),
+    CONF_BALANCING_ACTIVATION_VOLTAGE: (0x00A3, 1.0, 0, 0, 65535, 1),
+    CONF_BALANCING_ACTIVATION_VOLTAGE_DIFFERENCE: (0x00A4, 1.0, 0, 0, 65535, 1),
+    CONF_STATE_OF_CHARGE_SETTING: (0x00A7, 10.0, 0, 0.0, 100.0, 0.1),
+    CONF_MOSFET_OVERTEMPERATURE_ALARM: (0x00A8, 1.0, 40, -40, 100, 1),
 }
+
 
 CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
     {
+        cv.Optional(CONF_RATED_CAPACITY): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="Ah",
+            icon="mdi:battery",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_REFERENCE): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:flash",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_ACQUISITION_BOARD_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:circuit-board",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BOARD_1_CELL_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:battery-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BOARD_2_CELL_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:battery-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BOARD_3_CELL_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:battery-outline",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BOARD_1_TEMPERATURE_SENSOR_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:thermometer",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BOARD_2_TEMPERATURE_SENSOR_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:thermometer",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BOARD_3_TEMPERATURE_SENSOR_COUNT): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:thermometer",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BATTERY_TYPE): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_EMPTY,
+            icon="mdi:battery",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_SLEEP_WAIT_TIME): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_SECOND,
+            icon="mdi:sleep",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_OVERVOLTAGE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_OVERVOLTAGE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_UNDERVOLTAGE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_UNDERVOLTAGE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_TOTAL_OVERVOLTAGE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_VOLT,
+            icon="mdi:alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_TOTAL_OVERVOLTAGE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_VOLT,
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_TOTAL_UNDERVOLTAGE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_VOLT,
+            icon="mdi:alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_TOTAL_UNDERVOLTAGE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_VOLT,
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CHARGING_OVERCURRENT_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_AMPERE,
+            icon="mdi:alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CHARGING_OVERCURRENT_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_AMPERE,
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DISCHARGING_OVERCURRENT_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_AMPERE,
+            icon="mdi:alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DISCHARGING_OVERCURRENT_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_AMPERE,
+            icon="mdi:alert-circle",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CHARGING_OVERTEMPERATURE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CHARGING_OVERTEMPERATURE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CHARGING_UNDERTEMPERATURE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CHARGING_UNDERTEMPERATURE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DISCHARGING_OVERTEMPERATURE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DISCHARGING_OVERTEMPERATURE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DISCHARGING_UNDERTEMPERATURE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_DISCHARGING_UNDERTEMPERATURE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_DIFFERENCE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:delta",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_CELL_VOLTAGE_DIFFERENCE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:delta",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_TEMPERATURE_DIFFERENCE_WARNING): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_TEMPERATURE_DIFFERENCE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BALANCING_ACTIVATION_VOLTAGE): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:scale-balance",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_BALANCING_ACTIVATION_VOLTAGE_DIFFERENCE): number.number_schema(
+            DalyNumber,
+            unit_of_measurement="mV",
+            icon="mdi:scale-balance",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
         cv.Optional(CONF_STATE_OF_CHARGE_SETTING): number.number_schema(
             DalyNumber,
-            icon=ICON_STATE_OF_CHARGE_SETTING,
             unit_of_measurement=UNIT_PERCENT,
+            icon="mdi:battery-sync",
+            entity_category=ENTITY_CATEGORY_CONFIG,
+        ),
+        cv.Optional(CONF_MOSFET_OVERTEMPERATURE_ALARM): number.number_schema(
+            DalyNumber,
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:thermometer-alert",
+            entity_category=ENTITY_CATEGORY_CONFIG,
         ),
     }
 )
@@ -33,14 +345,15 @@ CONFIG_SCHEMA = DALY_BMS_BLE_COMPONENT_SCHEMA.extend(
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_DALY_BMS_BLE_ID])
-    for key, (address, factor, min_val, max_val, step) in NUMBERS.items():
+    for key, (address, factor, offset, min_val, max_val, step) in NUMBERS.items():
         if key in config:
             conf = config[key]
             var = await number.new_number(
                 conf, min_value=min_val, max_value=max_val, step=step
             )
             await cg.register_component(var, conf)
-            cg.add(getattr(hub, f"set_{key}_number")(var))
+            cg.add(hub.register_settings_number(address, var, factor, offset))
             cg.add(var.set_parent(hub))
             cg.add(var.set_holding_register(address))
             cg.add(var.set_factor(factor))
+            cg.add(var.set_offset(offset))

--- a/components/daly_bms_ble/number/daly_number.cpp
+++ b/components/daly_bms_ble/number/daly_number.cpp
@@ -7,7 +7,7 @@ static const char *const TAG = "daly_bms_ble.number";
 
 void DalyNumber::dump_config() { LOG_NUMBER("", "DalyBmsBle Number", this); }
 void DalyNumber::control(float value) {
-  if (this->parent_->write_register(this->holding_register_, (uint16_t) (value * this->factor_))) {
+  if (this->parent_->write_register(this->holding_register_, (uint16_t) (value * this->factor_ + this->offset_))) {
     this->publish_state(value);
   }
 }

--- a/components/daly_bms_ble/number/daly_number.h
+++ b/components/daly_bms_ble/number/daly_number.h
@@ -12,6 +12,7 @@ class DalyNumber : public number::Number, public Component {
   void set_parent(DalyBmsBle *parent) { this->parent_ = parent; };
   void set_holding_register(uint16_t holding_register) { this->holding_register_ = holding_register; };
   void set_factor(float factor) { this->factor_ = factor; };
+  void set_offset(float offset) { this->offset_ = offset; };
   void dump_config() override;
 
  protected:
@@ -19,6 +20,7 @@ class DalyNumber : public number::Number, public Component {
   DalyBmsBle *parent_;
   uint16_t holding_register_;
   float factor_{1.0f};
+  float offset_{0.0f};
 };
 
 }  // namespace esphome::daly_bms_ble

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -492,6 +492,251 @@ sensor:
       name: "capacity remaining"
       device_id: device1
 
+number:
+  - platform: daly_bms_ble
+    daly_bms_ble_id: bms0
+    # These entities write directly to BMS settings registers and have not been tested
+    # on real hardware. Use at your own risk - no guarantee is provided.
+    # state_of_charge_setting:
+    #   name: "state of charge setting"
+    #   device_id: device0
+    # rated_capacity:
+    #   name: "rated capacity"
+    #   device_id: device0
+    # cell_voltage_reference:
+    #   name: "cell voltage reference"
+    #   device_id: device0
+    # acquisition_board_count:
+    #   name: "acquisition board count"
+    #   device_id: device0
+    # board_1_cell_count:
+    #   name: "board 1 cell count"
+    #   device_id: device0
+    # board_2_cell_count:
+    #   name: "board 2 cell count"
+    #   device_id: device0
+    # board_3_cell_count:
+    #   name: "board 3 cell count"
+    #   device_id: device0
+    # board_1_temperature_sensor_count:
+    #   name: "board 1 temperature sensor count"
+    #   device_id: device0
+    # board_2_temperature_sensor_count:
+    #   name: "board 2 temperature sensor count"
+    #   device_id: device0
+    # board_3_temperature_sensor_count:
+    #   name: "board 3 temperature sensor count"
+    #   device_id: device0
+    # battery_type:
+    #   name: "battery type"
+    #   device_id: device0
+    # sleep_wait_time:
+    #   name: "sleep wait time"
+    #   device_id: device0
+    # cell_overvoltage_warning:
+    #   name: "cell overvoltage warning"
+    #   device_id: device0
+    # cell_overvoltage_alarm:
+    #   name: "cell overvoltage alarm"
+    #   device_id: device0
+    # cell_undervoltage_warning:
+    #   name: "cell undervoltage warning"
+    #   device_id: device0
+    # cell_undervoltage_alarm:
+    #   name: "cell undervoltage alarm"
+    #   device_id: device0
+    # total_overvoltage_warning:
+    #   name: "total overvoltage warning"
+    #   device_id: device0
+    # total_overvoltage_alarm:
+    #   name: "total overvoltage alarm"
+    #   device_id: device0
+    # total_undervoltage_warning:
+    #   name: "total undervoltage warning"
+    #   device_id: device0
+    # total_undervoltage_alarm:
+    #   name: "total undervoltage alarm"
+    #   device_id: device0
+    # charging_overcurrent_warning:
+    #   name: "charging overcurrent warning"
+    #   device_id: device0
+    # charging_overcurrent_alarm:
+    #   name: "charging overcurrent alarm"
+    #   device_id: device0
+    # discharging_overcurrent_warning:
+    #   name: "discharging overcurrent warning"
+    #   device_id: device0
+    # discharging_overcurrent_alarm:
+    #   name: "discharging overcurrent alarm"
+    #   device_id: device0
+    # charging_overtemperature_warning:
+    #   name: "charging overtemperature warning"
+    #   device_id: device0
+    # charging_overtemperature_alarm:
+    #   name: "charging overtemperature alarm"
+    #   device_id: device0
+    # charging_undertemperature_warning:
+    #   name: "charging undertemperature warning"
+    #   device_id: device0
+    # charging_undertemperature_alarm:
+    #   name: "charging undertemperature alarm"
+    #   device_id: device0
+    # discharging_overtemperature_warning:
+    #   name: "discharging overtemperature warning"
+    #   device_id: device0
+    # discharging_overtemperature_alarm:
+    #   name: "discharging overtemperature alarm"
+    #   device_id: device0
+    # discharging_undertemperature_warning:
+    #   name: "discharging undertemperature warning"
+    #   device_id: device0
+    # discharging_undertemperature_alarm:
+    #   name: "discharging undertemperature alarm"
+    #   device_id: device0
+    # cell_voltage_difference_warning:
+    #   name: "cell voltage difference warning"
+    #   device_id: device0
+    # cell_voltage_difference_alarm:
+    #   name: "cell voltage difference alarm"
+    #   device_id: device0
+    # temperature_difference_warning:
+    #   name: "temperature difference warning"
+    #   device_id: device0
+    # temperature_difference_alarm:
+    #   name: "temperature difference alarm"
+    #   device_id: device0
+    # balancing_activation_voltage:
+    #   name: "balancing activation voltage"
+    #   device_id: device0
+    # balancing_activation_voltage_difference:
+    #   name: "balancing activation voltage difference"
+    #   device_id: device0
+    # mosfet_overtemperature_alarm:
+    #   name: "mosfet overtemperature alarm"
+    #   device_id: device0
+
+  - platform: daly_bms_ble
+    daly_bms_ble_id: bms1
+    # These entities write directly to BMS settings registers and have not been tested
+    # on real hardware. Use at your own risk - no guarantee is provided.
+    # state_of_charge_setting:
+    #   name: "state of charge setting"
+    #   device_id: device1
+    # rated_capacity:
+    #   name: "rated capacity"
+    #   device_id: device1
+    # cell_voltage_reference:
+    #   name: "cell voltage reference"
+    #   device_id: device1
+    # acquisition_board_count:
+    #   name: "acquisition board count"
+    #   device_id: device1
+    # board_1_cell_count:
+    #   name: "board 1 cell count"
+    #   device_id: device1
+    # board_2_cell_count:
+    #   name: "board 2 cell count"
+    #   device_id: device1
+    # board_3_cell_count:
+    #   name: "board 3 cell count"
+    #   device_id: device1
+    # board_1_temperature_sensor_count:
+    #   name: "board 1 temperature sensor count"
+    #   device_id: device1
+    # board_2_temperature_sensor_count:
+    #   name: "board 2 temperature sensor count"
+    #   device_id: device1
+    # board_3_temperature_sensor_count:
+    #   name: "board 3 temperature sensor count"
+    #   device_id: device1
+    # battery_type:
+    #   name: "battery type"
+    #   device_id: device1
+    # sleep_wait_time:
+    #   name: "sleep wait time"
+    #   device_id: device1
+    # cell_overvoltage_warning:
+    #   name: "cell overvoltage warning"
+    #   device_id: device1
+    # cell_overvoltage_alarm:
+    #   name: "cell overvoltage alarm"
+    #   device_id: device1
+    # cell_undervoltage_warning:
+    #   name: "cell undervoltage warning"
+    #   device_id: device1
+    # cell_undervoltage_alarm:
+    #   name: "cell undervoltage alarm"
+    #   device_id: device1
+    # total_overvoltage_warning:
+    #   name: "total overvoltage warning"
+    #   device_id: device1
+    # total_overvoltage_alarm:
+    #   name: "total overvoltage alarm"
+    #   device_id: device1
+    # total_undervoltage_warning:
+    #   name: "total undervoltage warning"
+    #   device_id: device1
+    # total_undervoltage_alarm:
+    #   name: "total undervoltage alarm"
+    #   device_id: device1
+    # charging_overcurrent_warning:
+    #   name: "charging overcurrent warning"
+    #   device_id: device1
+    # charging_overcurrent_alarm:
+    #   name: "charging overcurrent alarm"
+    #   device_id: device1
+    # discharging_overcurrent_warning:
+    #   name: "discharging overcurrent warning"
+    #   device_id: device1
+    # discharging_overcurrent_alarm:
+    #   name: "discharging overcurrent alarm"
+    #   device_id: device1
+    # charging_overtemperature_warning:
+    #   name: "charging overtemperature warning"
+    #   device_id: device1
+    # charging_overtemperature_alarm:
+    #   name: "charging overtemperature alarm"
+    #   device_id: device1
+    # charging_undertemperature_warning:
+    #   name: "charging undertemperature warning"
+    #   device_id: device1
+    # charging_undertemperature_alarm:
+    #   name: "charging undertemperature alarm"
+    #   device_id: device1
+    # discharging_overtemperature_warning:
+    #   name: "discharging overtemperature warning"
+    #   device_id: device1
+    # discharging_overtemperature_alarm:
+    #   name: "discharging overtemperature alarm"
+    #   device_id: device1
+    # discharging_undertemperature_warning:
+    #   name: "discharging undertemperature warning"
+    #   device_id: device1
+    # discharging_undertemperature_alarm:
+    #   name: "discharging undertemperature alarm"
+    #   device_id: device1
+    # cell_voltage_difference_warning:
+    #   name: "cell voltage difference warning"
+    #   device_id: device1
+    # cell_voltage_difference_alarm:
+    #   name: "cell voltage difference alarm"
+    #   device_id: device1
+    # temperature_difference_warning:
+    #   name: "temperature difference warning"
+    #   device_id: device1
+    # temperature_difference_alarm:
+    #   name: "temperature difference alarm"
+    #   device_id: device1
+    # balancing_activation_voltage:
+    #   name: "balancing activation voltage"
+    #   device_id: device1
+    # balancing_activation_voltage_difference:
+    #   name: "balancing activation voltage difference"
+    #   device_id: device1
+    # mosfet_overtemperature_alarm:
+    #   name: "mosfet overtemperature alarm"
+    #   device_id: device1
+
 switch:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -221,6 +221,84 @@ number:
     daly_bms_ble_id: bms0
     state_of_charge_setting:
       name: "state of charge setting"
+    # These entities write directly to BMS settings registers and have not been tested
+    # on real hardware. Use at your own risk - no guarantee is provided.
+    # rated_capacity:
+    #   name: "rated capacity"
+    # cell_voltage_reference:
+    #   name: "cell voltage reference"
+    # acquisition_board_count:
+    #   name: "acquisition board count"
+    # board_1_cell_count:
+    #   name: "board 1 cell count"
+    # board_2_cell_count:
+    #   name: "board 2 cell count"
+    # board_3_cell_count:
+    #   name: "board 3 cell count"
+    # board_1_temperature_sensor_count:
+    #   name: "board 1 temperature sensor count"
+    # board_2_temperature_sensor_count:
+    #   name: "board 2 temperature sensor count"
+    # board_3_temperature_sensor_count:
+    #   name: "board 3 temperature sensor count"
+    # battery_type:
+    #   name: "battery type"
+    # sleep_wait_time:
+    #   name: "sleep wait time"
+    # cell_overvoltage_warning:
+    #   name: "cell overvoltage warning"
+    # cell_overvoltage_alarm:
+    #   name: "cell overvoltage alarm"
+    # cell_undervoltage_warning:
+    #   name: "cell undervoltage warning"
+    # cell_undervoltage_alarm:
+    #   name: "cell undervoltage alarm"
+    # total_overvoltage_warning:
+    #   name: "total overvoltage warning"
+    # total_overvoltage_alarm:
+    #   name: "total overvoltage alarm"
+    # total_undervoltage_warning:
+    #   name: "total undervoltage warning"
+    # total_undervoltage_alarm:
+    #   name: "total undervoltage alarm"
+    # charging_overcurrent_warning:
+    #   name: "charging overcurrent warning"
+    # charging_overcurrent_alarm:
+    #   name: "charging overcurrent alarm"
+    # discharging_overcurrent_warning:
+    #   name: "discharging overcurrent warning"
+    # discharging_overcurrent_alarm:
+    #   name: "discharging overcurrent alarm"
+    # charging_overtemperature_warning:
+    #   name: "charging overtemperature warning"
+    # charging_overtemperature_alarm:
+    #   name: "charging overtemperature alarm"
+    # charging_undertemperature_warning:
+    #   name: "charging undertemperature warning"
+    # charging_undertemperature_alarm:
+    #   name: "charging undertemperature alarm"
+    # discharging_overtemperature_warning:
+    #   name: "discharging overtemperature warning"
+    # discharging_overtemperature_alarm:
+    #   name: "discharging overtemperature alarm"
+    # discharging_undertemperature_warning:
+    #   name: "discharging undertemperature warning"
+    # discharging_undertemperature_alarm:
+    #   name: "discharging undertemperature alarm"
+    # cell_voltage_difference_warning:
+    #   name: "cell voltage difference warning"
+    # cell_voltage_difference_alarm:
+    #   name: "cell voltage difference alarm"
+    # temperature_difference_warning:
+    #   name: "temperature difference warning"
+    # temperature_difference_alarm:
+    #   name: "temperature difference alarm"
+    # balancing_activation_voltage:
+    #   name: "balancing activation voltage"
+    # balancing_activation_voltage_difference:
+    #   name: "balancing activation voltage difference"
+    # mosfet_overtemperature_alarm:
+    #   name: "mosfet overtemperature alarm"
 
 switch:
   - platform: daly_bms_ble

--- a/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
+++ b/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
@@ -97,11 +97,321 @@ TEST(DalyBmsBleSettingsTest, DischargingSwitchOn) {
 TEST(DalyBmsBleSettingsTest, StateOfChargeSetting) {
   TestableDalyBmsBle bms;
   TestNumber soc_setting;
-  bms.set_state_of_charge_setting_number(&soc_setting);
+  bms.register_settings_number(0x00A7, &soc_setting, 10.0f, 0.0f);
 
   bms.decode_settings_data_(SETTINGS_FRAME_1);
 
   EXPECT_NEAR(soc_setting.state, 68.0f, 0.01f);
+}
+
+TEST(DalyBmsBleSettingsTest, RatedCapacity) {
+  TestableDalyBmsBle bms;
+  TestNumber rated_capacity;
+  bms.register_settings_number(0x0080, &rated_capacity, 10.0f, 0.0f);
+
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+
+  EXPECT_NEAR(rated_capacity.state, 105.0f, 0.01f);  // raw=1050, 1050/10=105.0
+}
+
+TEST(DalyBmsBleSettingsTest, MosfetOvertemperatureAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber mos_temp;
+  bms.register_settings_number(0x00A8, &mos_temp, 1.0f, 40.0f);
+
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+
+  EXPECT_NEAR(mos_temp.state, 47.0f, 0.01f);  // raw=87, (87-40)/1=47
+}
+
+TEST(DalyBmsBleSettingsTest, ChargingOvercurrentWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber current_warning;
+  bms.register_settings_number(0x0093, &current_warning, 10.0f, 30000.0f);
+
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+
+  EXPECT_NEAR(current_warning.state, -10.0f, 0.01f);  // raw=29900, (29900-30000)/10=-10.0
+}
+
+TEST(DalyBmsBleSettingsTest, CellVoltageReference) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0081, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 3200.0f, 0.01f);  // raw=3200, 3200/1=3200
+}
+
+TEST(DalyBmsBleSettingsTest, AcquisitionBoardCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0082, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 1.0f, 0.01f);  // raw=1
+}
+
+TEST(DalyBmsBleSettingsTest, Board1CellCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0083, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 4.0f, 0.01f);  // raw=4
+}
+
+TEST(DalyBmsBleSettingsTest, Board2CellCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0084, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=0
+}
+
+TEST(DalyBmsBleSettingsTest, Board3CellCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0085, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=0
+}
+
+TEST(DalyBmsBleSettingsTest, Board1TemperatureSensorCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0086, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 1.0f, 0.01f);  // raw=1
+}
+
+TEST(DalyBmsBleSettingsTest, Board2TemperatureSensorCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0087, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=0
+}
+
+TEST(DalyBmsBleSettingsTest, Board3TemperatureSensorCount) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0088, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=0
+}
+
+TEST(DalyBmsBleSettingsTest, BatteryType) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0089, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=0
+}
+
+TEST(DalyBmsBleSettingsTest, SleepWaitTime) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x008A, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 7200.0f, 0.01f);  // raw=7200
+}
+
+TEST(DalyBmsBleSettingsTest, CellOvervoltageWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x008B, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 3500.0f, 0.01f);  // raw=3500
+}
+
+TEST(DalyBmsBleSettingsTest, CellOvervoltageAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x008C, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 3500.0f, 0.01f);  // raw=3500
+}
+
+TEST(DalyBmsBleSettingsTest, CellUndervoltageWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x008D, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 2600.0f, 0.01f);  // raw=2600
+}
+
+TEST(DalyBmsBleSettingsTest, CellUndervoltageAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x008E, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 2600.0f, 0.01f);  // raw=2600
+}
+
+TEST(DalyBmsBleSettingsTest, TotalOvervoltageWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x008F, &n, 10.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 14.0f, 0.01f);  // raw=140, 140/10=14.0
+}
+
+TEST(DalyBmsBleSettingsTest, TotalOvervoltageAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0090, &n, 10.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 14.0f, 0.01f);  // raw=140, 140/10=14.0
+}
+
+TEST(DalyBmsBleSettingsTest, TotalUndervoltageWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0091, &n, 10.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 10.4f, 0.01f);  // raw=104, 104/10=10.4
+}
+
+TEST(DalyBmsBleSettingsTest, TotalUndervoltageAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0092, &n, 10.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 10.4f, 0.01f);  // raw=104, 104/10=10.4
+}
+
+TEST(DalyBmsBleSettingsTest, ChargingOvercurrentAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0094, &n, 10.0f, 30000.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, -10.0f, 0.01f);  // raw=29900, (29900-30000)/10=-10.0
+}
+
+TEST(DalyBmsBleSettingsTest, DischargingOvercurrentWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0095, &n, 10.0f, 30000.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, -16.0f, 0.01f);  // raw=29840, (29840-30000)/10=-16.0
+}
+
+TEST(DalyBmsBleSettingsTest, DischargingOvercurrentAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0096, &n, 10.0f, 30000.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 16.0f, 0.01f);  // raw=30160, (30160-30000)/10=16.0
+}
+
+TEST(DalyBmsBleSettingsTest, ChargingOvertemperatureWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0097, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 45.0f, 0.01f);  // raw=85, (85-40)/1=45
+}
+
+TEST(DalyBmsBleSettingsTest, ChargingOvertemperatureAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0098, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 45.0f, 0.01f);  // raw=85, (85-40)/1=45
+}
+
+TEST(DalyBmsBleSettingsTest, ChargingUndertemperatureWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x0099, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=40, (40-40)/1=0
+}
+
+TEST(DalyBmsBleSettingsTest, ChargingUndertemperatureAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x009A, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 0.0f, 0.01f);  // raw=40, (40-40)/1=0
+}
+
+TEST(DalyBmsBleSettingsTest, DischargingOvertemperatureWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x009B, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 70.0f, 0.01f);  // raw=110, (110-40)/1=70
+}
+
+TEST(DalyBmsBleSettingsTest, DischargingOvertemperatureAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x009C, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 70.0f, 0.01f);  // raw=110, (110-40)/1=70
+}
+
+TEST(DalyBmsBleSettingsTest, DischargingUndertemperatureWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x009D, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, -1.0f, 0.01f);  // raw=39, (39-40)/1=-1
+}
+
+TEST(DalyBmsBleSettingsTest, DischargingUndertemperatureAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x009E, &n, 1.0f, 40.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, -1.0f, 0.01f);  // raw=39, (39-40)/1=-1
+}
+
+TEST(DalyBmsBleSettingsTest, CellVoltageDifferenceWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x009F, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 255.0f, 0.01f);  // raw=255
+}
+
+TEST(DalyBmsBleSettingsTest, CellVoltageDifferenceAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x00A0, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 255.0f, 0.01f);  // raw=255
+}
+
+TEST(DalyBmsBleSettingsTest, TemperatureDifferenceWarning) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x00A1, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 255.0f, 0.01f);  // raw=255
+}
+
+TEST(DalyBmsBleSettingsTest, TemperatureDifferenceAlarm) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x00A2, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 255.0f, 0.01f);  // raw=255
+}
+
+TEST(DalyBmsBleSettingsTest, BalancingActivationVoltage) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x00A3, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 3200.0f, 0.01f);  // raw=3200
+}
+
+TEST(DalyBmsBleSettingsTest, BalancingActivationVoltageDifference) {
+  TestableDalyBmsBle bms;
+  TestNumber n;
+  bms.register_settings_number(0x00A4, &n, 1.0f, 0.0f);
+  bms.decode_settings_data_(SETTINGS_FRAME_1);
+  EXPECT_NEAR(n.state, 20.0f, 0.01f);  // raw=20
 }
 
 TEST(DalyBmsBleSettingsTest, NullSensorsDoNotCrash) {

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -193,6 +193,88 @@ sensor:
     capacity_remaining:
       name: "capacity remaining"
 
+number:
+  - platform: daly_bms_ble
+    daly_bms_ble_id: bms0
+    state_of_charge_setting:
+      name: "state of charge setting"
+    rated_capacity:
+      name: "rated capacity"
+    cell_voltage_reference:
+      name: "cell voltage reference"
+    acquisition_board_count:
+      name: "acquisition board count"
+    board_1_cell_count:
+      name: "board 1 cell count"
+    board_2_cell_count:
+      name: "board 2 cell count"
+    board_3_cell_count:
+      name: "board 3 cell count"
+    board_1_temperature_sensor_count:
+      name: "board 1 temperature sensor count"
+    board_2_temperature_sensor_count:
+      name: "board 2 temperature sensor count"
+    board_3_temperature_sensor_count:
+      name: "board 3 temperature sensor count"
+    battery_type:
+      name: "battery type"
+    sleep_wait_time:
+      name: "sleep wait time"
+    cell_overvoltage_warning:
+      name: "cell overvoltage warning"
+    cell_overvoltage_alarm:
+      name: "cell overvoltage alarm"
+    cell_undervoltage_warning:
+      name: "cell undervoltage warning"
+    cell_undervoltage_alarm:
+      name: "cell undervoltage alarm"
+    total_overvoltage_warning:
+      name: "total overvoltage warning"
+    total_overvoltage_alarm:
+      name: "total overvoltage alarm"
+    total_undervoltage_warning:
+      name: "total undervoltage warning"
+    total_undervoltage_alarm:
+      name: "total undervoltage alarm"
+    charging_overcurrent_warning:
+      name: "charging overcurrent warning"
+    charging_overcurrent_alarm:
+      name: "charging overcurrent alarm"
+    discharging_overcurrent_warning:
+      name: "discharging overcurrent warning"
+    discharging_overcurrent_alarm:
+      name: "discharging overcurrent alarm"
+    charging_overtemperature_warning:
+      name: "charging overtemperature warning"
+    charging_overtemperature_alarm:
+      name: "charging overtemperature alarm"
+    charging_undertemperature_warning:
+      name: "charging undertemperature warning"
+    charging_undertemperature_alarm:
+      name: "charging undertemperature alarm"
+    discharging_overtemperature_warning:
+      name: "discharging overtemperature warning"
+    discharging_overtemperature_alarm:
+      name: "discharging overtemperature alarm"
+    discharging_undertemperature_warning:
+      name: "discharging undertemperature warning"
+    discharging_undertemperature_alarm:
+      name: "discharging undertemperature alarm"
+    cell_voltage_difference_warning:
+      name: "cell voltage difference warning"
+    cell_voltage_difference_alarm:
+      name: "cell voltage difference alarm"
+    temperature_difference_warning:
+      name: "temperature difference warning"
+    temperature_difference_alarm:
+      name: "temperature difference alarm"
+    balancing_activation_voltage:
+      name: "balancing activation voltage"
+    balancing_activation_voltage_difference:
+      name: "balancing activation voltage difference"
+    mosfet_overtemperature_alarm:
+      name: "mosfet overtemperature alarm"
+
 text_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -86,15 +86,72 @@ class TestButtonConstants:
 
 
 class TestNumberConstants:
-    def test_numbers_dict(self):
-        assert number.CONF_STATE_OF_CHARGE_SETTING in number.NUMBERS
+    def test_numbers_count(self):
+        assert len(number.NUMBERS) == 39
+
+    def test_number_addresses_are_unique(self):
+        addresses = [address for address, *_ in number.NUMBERS.values()]
+        assert len(addresses) == len(set(addresses))
 
     def test_number_tuple_structure(self):
-        for address, factor, min_val, max_val, step in number.NUMBERS.values():
+        for address, factor, offset, min_val, max_val, step in number.NUMBERS.values():
             assert isinstance(address, int)
             assert factor > 0
             assert min_val < max_val
             assert step > 0
+
+    def test_rated_capacity_address(self):
+        assert number.NUMBERS[number.CONF_RATED_CAPACITY][0] == 0x0080
+
+    def test_mosfet_overtemperature_alarm_address(self):
+        assert number.NUMBERS[number.CONF_MOSFET_OVERTEMPERATURE_ALARM][0] == 0x00A8
+
+    def test_state_of_charge_setting_address(self):
+        assert number.NUMBERS[number.CONF_STATE_OF_CHARGE_SETTING][0] == 0x00A7
+
+    def test_all_number_keys_present(self):
+        expected = {
+            number.CONF_RATED_CAPACITY,
+            number.CONF_CELL_VOLTAGE_REFERENCE,
+            number.CONF_ACQUISITION_BOARD_COUNT,
+            number.CONF_BOARD_1_CELL_COUNT,
+            number.CONF_BOARD_2_CELL_COUNT,
+            number.CONF_BOARD_3_CELL_COUNT,
+            number.CONF_BOARD_1_TEMPERATURE_SENSOR_COUNT,
+            number.CONF_BOARD_2_TEMPERATURE_SENSOR_COUNT,
+            number.CONF_BOARD_3_TEMPERATURE_SENSOR_COUNT,
+            number.CONF_BATTERY_TYPE,
+            number.CONF_SLEEP_WAIT_TIME,
+            number.CONF_CELL_OVERVOLTAGE_WARNING,
+            number.CONF_CELL_OVERVOLTAGE_ALARM,
+            number.CONF_CELL_UNDERVOLTAGE_WARNING,
+            number.CONF_CELL_UNDERVOLTAGE_ALARM,
+            number.CONF_TOTAL_OVERVOLTAGE_WARNING,
+            number.CONF_TOTAL_OVERVOLTAGE_ALARM,
+            number.CONF_TOTAL_UNDERVOLTAGE_WARNING,
+            number.CONF_TOTAL_UNDERVOLTAGE_ALARM,
+            number.CONF_CHARGING_OVERCURRENT_WARNING,
+            number.CONF_CHARGING_OVERCURRENT_ALARM,
+            number.CONF_DISCHARGING_OVERCURRENT_WARNING,
+            number.CONF_DISCHARGING_OVERCURRENT_ALARM,
+            number.CONF_CHARGING_OVERTEMPERATURE_WARNING,
+            number.CONF_CHARGING_OVERTEMPERATURE_ALARM,
+            number.CONF_CHARGING_UNDERTEMPERATURE_WARNING,
+            number.CONF_CHARGING_UNDERTEMPERATURE_ALARM,
+            number.CONF_DISCHARGING_OVERTEMPERATURE_WARNING,
+            number.CONF_DISCHARGING_OVERTEMPERATURE_ALARM,
+            number.CONF_DISCHARGING_UNDERTEMPERATURE_WARNING,
+            number.CONF_DISCHARGING_UNDERTEMPERATURE_ALARM,
+            number.CONF_CELL_VOLTAGE_DIFFERENCE_WARNING,
+            number.CONF_CELL_VOLTAGE_DIFFERENCE_ALARM,
+            number.CONF_TEMPERATURE_DIFFERENCE_WARNING,
+            number.CONF_TEMPERATURE_DIFFERENCE_ALARM,
+            number.CONF_BALANCING_ACTIVATION_VOLTAGE,
+            number.CONF_BALANCING_ACTIVATION_VOLTAGE_DIFFERENCE,
+            number.CONF_STATE_OF_CHARGE_SETTING,
+            number.CONF_MOSFET_OVERTEMPERATURE_ALARM,
+        }
+        assert set(number.NUMBERS.keys()) == expected
 
 
 class TestTextSensorConstants:


### PR DESCRIPTION
## Summary

- Expose all configurable BMS settings registers (0x80–0xA8) as writable `number` entities
- Supports 39 parameters including cell voltage thresholds, current limits, temperature protection, balancing, SOC setting, and rated capacity
- Register-to-entity mapping is data-driven in Python; C++ hub uses a `std::map` keyed by register address — no per-entity boilerplate
- Factor/offset conversion: `user = (raw - offset) / factor` on read, `raw = user × factor + offset` on write
- Registers 0xA5/0xA6 (charging/discharging MOS switches) remain as `switch` entities

## Test plan

- [x] Python schema tests: `test_number_tuple_structure` updated for 6-tuple format
- [x] C++ unit tests: `StateOfChargeSetting`, `RatedCapacity`, `MosfetOvertemperatureAlarm`, `ChargingOvercurrentWarning` cover plain, offset, and signed-offset conversions
- [ ] CI: `cpp_unit_test.py daly_bms_ble` and ESPHome config validation

Closes #4