### PR TITLE
Move BLE MAC address to secrets.yaml

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -4,8 +4,6 @@ substitutions:
   bms1: "${name} bms1"
   device_description: "Monitor a DALY Battery Management System via BLE"
   external_components_source: github://syssi/esphome-daly-bms@main
-  bms0_mac_address: !secret bms0_mac_address
-  bms1_mac_address: !secret bms1_mac_address
 
 esphome:
   name: ${name}
@@ -61,9 +59,9 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${bms0_mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
-  - mac_address: ${bms1_mac_address}
+  - mac_address: !secret bms1_mac_address
     id: client1
 
 daly_bms_ble:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: daly-bms-ble
   device_description: "Monitor a DALY Battery Management System via BLE"
   external_components_source: github://syssi/esphome-daly-bms@main
-  mac_address: !secret bms0_mac_address
 
 esphome:
   name: ${name}
@@ -51,7 +50,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 daly_bms_ble:

--- a/test-esp32.sh
+++ b/test-esp32.sh
@@ -6,4 +6,4 @@ else
   C="components"
 fi
 
-esphome -s mac_address B0:A7:32:13:57:72 -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}
+esphome -s external_components_source $C ${1:-run} ${2:-esp32-ble-example-faker.yaml}

--- a/tests/esp32-ble-alarms-faker.yaml
+++ b/tests/esp32-ble-alarms-faker.yaml
@@ -365,7 +365,6 @@ substitutions:
   name: daly-bms-ble
   device_description: "Monitor a DALY Battery Management System via BLE"
   external_components_source: github://syssi/esphome-daly-bms@main
-  mac_address: !secret bms0_mac_address
 
 esphome:
   name: ${name}
@@ -404,7 +403,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 daly_bms_ble:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -2,7 +2,6 @@ substitutions:
   name: esp32c6-compatibility-test
   device_description: "Verify the project builds from source on ESP32C6"
   external_components_source: github://syssi/esphome-daly-bms@main
-  mac_address: !secret bms0_mac_address
 
 esphome:
   name: ${name}
@@ -39,7 +38,7 @@ esp32_ble_tracker:
     active: false
 
 ble_client:
-  - mac_address: ${mac_address}
+  - mac_address: !secret bms0_mac_address
     id: client0
 
 daly_bms_ble:


### PR DESCRIPTION
## Summary

- Reference the BLE client MAC address via `!secret bms0_mac_address` directly in `ble_client:` instead of routing through a YAML substitution
- Remove the now-unused substitution entries