### PR TITLE
Add hint for `status_registers: 80` to enable mosfet/board temperature sensors

### DIFF
--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -68,12 +68,18 @@ daly_bms_ble:
   - ble_client_id: client0
     id: bms0
     password: 12345678
+    # Use status_registers: 80 to enable the mosfet_temperature and board_temperature sensors.
+    # Supported on the Daly Smart BMS (Blue Series) and more.
     status_registers: 62
+    # status_registers: 80
     update_interval: 10s
   - ble_client_id: client1
     id: bms1
     password: 12345678
+    # Use status_registers: 80 to enable the mosfet_temperature and board_temperature sensors.
+    # Supported on the Daly Smart BMS (Blue Series) and more.
     status_registers: 62
+    # status_registers: 80
     update_interval: 10s
 
 binary_sensor:

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -57,7 +57,10 @@ daly_bms_ble:
   - ble_client_id: client0
     id: bms0
     password: 12345678
+    # Use status_registers: 80 to enable the mosfet_temperature and board_temperature sensors.
+    # Supported on the Daly Smart BMS (Blue Series) and more.
     status_registers: 62
+    # status_registers: 80
     update_interval: 10s
 
 binary_sensor:
@@ -211,6 +214,7 @@ sensor:
       name: "capacity remaining"
     balance_current:
       name: "balance current"
+    # mosfet_temperature and board_temperature require status_registers: 80
     mosfet_temperature:
       name: "mosfet temperature"
     board_temperature:


### PR DESCRIPTION
`mosfet_temperature` and `board_temperature` are only populated when `status_registers: 80` is configured. With the default value of `62` both sensors remain unavailable indefinitely — a non-obvious trap for users.

Adds a comment and a commented-out alternative `status_registers: 80` line to the `daly_bms_ble` section in both example configs. A second comment is placed directly above the affected sensors in `esp32-ble-example.yaml` to make the dependency visible where it matters most.

fixes #102