### PR TITLE
Add command queue and poll settings frame on every update cycle

### DIFF
--- a/components/daly_bms_ble/__init__.py
+++ b/components/daly_bms_ble/__init__.py
@@ -30,7 +30,9 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(DalyBmsBle),
             cv.Optional(CONF_PASSWORD, default="12345678"): cv.uint32_t,
             cv.Optional(CONF_STATUS_REGISTERS, default=62): cv.one_of(62, 80, int=True),
-            cv.Optional(CONF_RESPONSE_TIMEOUT, default="3s"): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_RESPONSE_TIMEOUT, default="3s"
+            ): cv.positive_time_period_milliseconds,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)

--- a/components/daly_bms_ble/__init__.py
+++ b/components/daly_bms_ble/__init__.py
@@ -10,6 +10,7 @@ MULTI_CONF = True
 
 CONF_DALY_BMS_BLE_ID = "daly_bms_ble_id"
 CONF_STATUS_REGISTERS = "status_registers"
+CONF_RESPONSE_TIMEOUT = "response_timeout"
 
 daly_bms_ble_ns = cg.esphome_ns.namespace("daly_bms_ble")
 DalyBmsBle = daly_bms_ble_ns.class_(
@@ -29,6 +30,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(DalyBmsBle),
             cv.Optional(CONF_PASSWORD, default="12345678"): cv.uint32_t,
             cv.Optional(CONF_STATUS_REGISTERS, default=62): cv.one_of(62, 80, int=True),
+            cv.Optional(CONF_RESPONSE_TIMEOUT, default="3s"): cv.positive_time_period_milliseconds,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -43,3 +45,4 @@ async def to_code(config):
 
     cg.add(var.set_password(config[CONF_PASSWORD]))
     cg.add(var.set_status_registers(config[CONF_STATUS_REGISTERS]))
+    cg.add(var.set_response_timeout(config[CONF_RESPONSE_TIMEOUT]))

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -24,6 +24,8 @@ static const uint8_t DALY_FUNCTION_READ = 0x03;
 static const uint8_t DALY_FUNCTION_WRITE = 0x06;
 
 static const uint16_t DALY_COMMAND_REQ_STATUS_START = 0;
+static const uint16_t DALY_COMMAND_REQ_SETTINGS_START = 0x0080;
+static const uint16_t DALY_COMMAND_REQ_SETTINGS_COUNT = 41;
 
 static const uint8_t DALY_FRAME_LEN_STATUS_80_REGISTERS = 80 * 2;
 static const uint8_t DALY_FRAME_LEN_STATUS_62_REGISTERS = 62 * 2;
@@ -132,10 +134,28 @@ std::array<uint8_t, 8> DalyBmsBle::build_frame_(uint8_t function, uint16_t addre
   return frame;
 }
 
-#ifdef USE_ESP32
-bool DalyBmsBle::send_command(uint8_t function, uint16_t address, uint16_t value) {
-  auto frame = this->build_frame_(function, address, value);
+void DalyBmsBle::queue_command_(uint8_t function, uint16_t address, uint16_t value) {
+  if (!this->queue_.enqueue(function, address, value))
+    ESP_LOGW(TAG, "Command queue full, dropping: func=0x%02X addr=0x%04X val=0x%04X", function, address, value);
+}
 
+void DalyBmsBle::advance_command_queue_() {
+  this->queue_.advance();
+  this->send_next_command_();
+}
+
+void DalyBmsBle::send_command(uint8_t function, uint16_t address, uint16_t value) {
+  this->queue_command_(function, address, value);
+  this->send_next_command_();
+}
+
+#ifdef USE_ESP32
+void DalyBmsBle::send_next_command_() {
+  if (this->queue_.pending() || this->node_state != espbt::ClientState::ESTABLISHED || this->queue_.empty())
+    return;
+  auto &cmd = this->queue_.front();
+
+  auto frame = this->build_frame_(cmd.function, cmd.address, cmd.value);
   ESP_LOGD(TAG, "Send command (handle 0x%02X): %s", this->char_command_handle_,
            format_hex_pretty(frame.data(), frame.size()).c_str());  // NOLINT
 
@@ -145,11 +165,17 @@ bool DalyBmsBle::send_command(uint8_t function, uint16_t address, uint16_t value
 
   if (status) {
     ESP_LOGW(TAG, "[%s] esp_ble_gattc_write_char failed, status=%d", ADDR_STR(this->parent_->address_str()), status);
+    this->queue_.advance();
+    return;
   }
 
-  return (status == 0);
+  this->queue_.mark_pending(millis());
 }
+#else
+void DalyBmsBle::send_next_command_() {}
+#endif
 
+#ifdef USE_ESP32
 void DalyBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                      esp_ble_gattc_cb_param_t *param) {
   switch (event) {
@@ -158,6 +184,8 @@ void DalyBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
     }
     case ESP_GATTC_DISCONNECT_EVT: {
       this->node_state = espbt::ClientState::IDLE;
+
+      this->queue_.reset();
 
       // this->publish_state_(this->voltage_sensor_, NAN);
 
@@ -219,6 +247,13 @@ void DalyBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
 }
 #endif  // USE_ESP32
 
+void DalyBmsBle::loop() {
+  if (this->queue_.timed_out(millis())) {
+    ESP_LOGW(TAG, "Command timeout, advancing queue");
+    this->advance_command_queue_();
+  }
+}
+
 void DalyBmsBle::update() {
 #ifdef USE_ESP32
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
@@ -226,7 +261,9 @@ void DalyBmsBle::update() {
     return;
   }
 
-  this->send_command(DALY_FUNCTION_READ, DALY_COMMAND_REQ_STATUS_START, this->status_registers_);
+  this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_STATUS_START, this->status_registers_);
+  this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_SETTINGS_START, DALY_COMMAND_REQ_SETTINGS_COUNT);
+  this->send_next_command_();
 #endif
 }
 
@@ -244,6 +281,8 @@ void DalyBmsBle::on_daly_bms_ble_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "CRC check failed! 0x%04X != 0x%04X", computed_crc, remote_crc);
     return;
   }
+
+  this->advance_command_queue_();
 
   if (data[1] == DALY_FUNCTION_WRITE) {
     ESP_LOGD(TAG, "Write register acknowledged (reg=0x%02X%02X, value=0x%02X%02X)", data[2], data[3], data[4], data[5]);

--- a/components/daly_bms_ble/daly_bms_ble.h
+++ b/components/daly_bms_ble/daly_bms_ble.h
@@ -29,6 +29,7 @@ class DalyBmsBle :
  public:
   void dump_config() override;
   void update() override;
+  void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
@@ -116,11 +117,12 @@ class DalyBmsBle :
   void register_settings_number(uint16_t address, number::Number *number, float factor, float offset) {
     this->settings_numbers_[address] = {number, factor, offset};
   }
+  void send_command(uint8_t function, uint16_t address, uint16_t value);
+  void set_response_timeout(uint32_t ms) { queue_.set_timeout_ms(ms); }
 #ifdef USE_ESP32
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
-  bool write_register(uint16_t address, uint16_t value) { return send_command(0x06, address, value); }
-  bool send_command(uint8_t function, uint16_t address, uint16_t value);
+  void write_register(uint16_t address, uint16_t value) { send_command(0x06, address, value); }
 #endif
 
   void on_daly_bms_ble_data(const std::vector<uint8_t> &data);
@@ -176,6 +178,58 @@ class DalyBmsBle :
   struct Temperature {
     sensor::Sensor *temperature_sensor_{nullptr};
   } temperatures_[8];
+
+  struct CommandQueue {
+    static const size_t LENGTH = 10;
+
+    struct Command {
+      uint8_t function;
+      uint16_t address;
+      uint16_t value;
+    };
+
+    void set_timeout_ms(uint32_t ms) { timeout_ms_ = ms; }
+
+    bool enqueue(uint8_t function, uint16_t address, uint16_t value) {
+      uint8_t next = (tail_ + 1) % LENGTH;
+      if (next == head_)
+        return false;
+      commands_[tail_] = {function, address, value};
+      tail_ = next;
+      return true;
+    }
+    const Command &front() const { return commands_[head_]; }
+    void advance() {
+      if (empty())
+        return;
+      head_ = (head_ + 1) % LENGTH;
+      pending_ = false;
+    }
+    void mark_pending(uint32_t now) {
+      pending_ = true;
+      start_millis_ = now;
+    }
+    void reset() {
+      head_ = tail_ = 0;
+      pending_ = false;
+    }
+    bool empty() const { return head_ == tail_; }
+    bool pending() const { return pending_; }
+    bool timed_out(uint32_t now) const { return pending_ && (now - start_millis_ > timeout_ms_); }
+    uint8_t size() const { return (tail_ + LENGTH - head_) % LENGTH; }
+
+   private:
+    Command commands_[LENGTH];
+    uint8_t head_{0};
+    uint8_t tail_{0};
+    bool pending_{false};
+    uint32_t start_millis_{0};
+    uint32_t timeout_ms_{3000};
+  } queue_;
+
+  void queue_command_(uint8_t function, uint16_t address, uint16_t value);
+  void send_next_command_();
+  void advance_command_queue_();
 
 #ifdef USE_ESP32
   uint16_t char_notify_handle_{0};

--- a/components/daly_bms_ble/number/daly_number.cpp
+++ b/components/daly_bms_ble/number/daly_number.cpp
@@ -7,9 +7,8 @@ static const char *const TAG = "daly_bms_ble.number";
 
 void DalyNumber::dump_config() { LOG_NUMBER("", "DalyBmsBle Number", this); }
 void DalyNumber::control(float value) {
-  if (this->parent_->write_register(this->holding_register_, (uint16_t) (value * this->factor_ + this->offset_))) {
-    this->publish_state(value);
-  }
+  this->parent_->write_register(this->holding_register_, (uint16_t) (value * this->factor_ + this->offset_));
+  this->publish_state(value);
 }
 
 }  // namespace esphome::daly_bms_ble

--- a/components/daly_bms_ble/switch/daly_switch.cpp
+++ b/components/daly_bms_ble/switch/daly_switch.cpp
@@ -10,9 +10,8 @@ static const uint8_t DALY_FUNCTION_WRITE = 0x06;
 
 void DalySwitch::dump_config() { LOG_SWITCH("", "DalyBmsBle Switch", this); }
 void DalySwitch::write_state(bool state) {
-  if (this->parent_->send_command(DALY_FUNCTION_WRITE, this->holding_register_, (uint16_t) state)) {
-    this->publish_state(state);
-  }
+  this->parent_->send_command(DALY_FUNCTION_WRITE, this->holding_register_, (uint16_t) state);
+  this->publish_state(state);
 }
 
 }  // namespace esphome::daly_bms_ble

--- a/esp32-ble-example-faker.yaml
+++ b/esp32-ble-example-faker.yaml
@@ -4,6 +4,7 @@ daly_bms_ble:
   - ble_client_id: client0
     id: bms0
     update_interval: 10s
+    response_timeout: 3s
 
 interval:
   - interval: 10s

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -73,6 +73,7 @@ daly_bms_ble:
     status_registers: 62
     # status_registers: 80
     update_interval: 10s
+    response_timeout: 3s
   - ble_client_id: client1
     id: bms1
     password: 12345678
@@ -81,6 +82,7 @@ daly_bms_ble:
     status_registers: 62
     # status_registers: 80
     update_interval: 10s
+    response_timeout: 3s
 
 binary_sensor:
   - platform: daly_bms_ble

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -62,6 +62,7 @@ daly_bms_ble:
     status_registers: 62
     # status_registers: 80
     update_interval: 10s
+    response_timeout: 3s
 
 binary_sensor:
   - platform: daly_bms_ble

--- a/tests/components/daly_bms_ble/common.h
+++ b/tests/components/daly_bms_ble/common.h
@@ -22,6 +22,14 @@ class TestableDalyBmsBle : public DalyBmsBle {
   using DalyBmsBle::decode_version_data_;
   using DalyBmsBle::decode_password_data_;
   using DalyBmsBle::on_daly_bms_ble_data;
+
+  using DalyBmsBle::CommandQueue;
+  using DalyBmsBle::queue_command_;
+  using DalyBmsBle::advance_command_queue_;
+
+  uint8_t queue_size() const { return queue_.size(); }
+  bool command_pending() const { return queue_.pending(); }
+  void reset_queue() { queue_.reset(); }
 };
 
 // ── Real frames from esp32-ble-example-faker.yaml ────────────────────────────

--- a/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
+++ b/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
@@ -879,4 +879,122 @@ TEST(DalyBmsBleRequestFrameTest, Password) {
             (std::array<uint8_t, 8>{0xD2, 0x03, 0x00, 0xC9, 0x00, 0x03, 0xC6, 0x56}));
 }
 
+// ── Command queue ────────────────────────────────────────────────────────────
+
+TEST(DalyBmsBleQueueTest, InitiallyEmpty) {
+  TestableDalyBmsBle bms;
+  EXPECT_EQ(bms.queue_size(), 0);
+  EXPECT_FALSE(bms.command_pending());
+}
+
+TEST(DalyBmsBleQueueTest, Enqueue) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+  EXPECT_EQ(bms.queue_size(), 1);
+}
+
+TEST(DalyBmsBleQueueTest, MultipleEnqueue) {
+  TestableDalyBmsBle bms;
+  for (uint8_t i = 0; i < 5; i++)
+    bms.queue_command_(0x03, i, 0);
+  EXPECT_EQ(bms.queue_size(), 5);
+}
+
+TEST(DalyBmsBleQueueTest, QueueFullDropsCommand) {
+  TestableDalyBmsBle bms;
+  const uint8_t max_size = TestableDalyBmsBle::CommandQueue::LENGTH - 1;
+  for (uint8_t i = 0; i < max_size; i++)
+    bms.queue_command_(0x03, i, 0);
+  EXPECT_EQ(bms.queue_size(), max_size);
+
+  bms.queue_command_(0x03, 0xAA, 0);
+  EXPECT_EQ(bms.queue_size(), max_size);
+}
+
+TEST(DalyBmsBleQueueTest, AdvanceDecrementsSize) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+  bms.queue_command_(0x03, 0x0080, 41);
+
+  bms.advance_command_queue_();
+
+  EXPECT_EQ(bms.queue_size(), 1);
+  EXPECT_FALSE(bms.command_pending());
+}
+
+TEST(DalyBmsBleQueueTest, AdvanceDrainsFully) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+  bms.queue_command_(0x03, 0x0080, 41);
+
+  bms.advance_command_queue_();
+  bms.advance_command_queue_();
+
+  EXPECT_EQ(bms.queue_size(), 0);
+}
+
+TEST(DalyBmsBleQueueTest, ResetClearsQueue) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+  bms.queue_command_(0x03, 0x0080, 41);
+
+  bms.reset_queue();
+
+  EXPECT_EQ(bms.queue_size(), 0);
+  EXPECT_FALSE(bms.command_pending());
+}
+
+TEST(DalyBmsBleQueueTest, WrapAround) {
+  TestableDalyBmsBle bms;
+  for (uint8_t i = 0; i < 9; i++)
+    bms.queue_command_(0x03, i, 0);
+  for (int i = 0; i < 5; i++)
+    bms.advance_command_queue_();
+
+  EXPECT_EQ(bms.queue_size(), 4);
+
+  for (uint8_t i = 0; i < 5; i++)
+    bms.queue_command_(0x03, 0x10 + i, 0);
+
+  EXPECT_EQ(bms.queue_size(), 9);
+}
+
+TEST(DalyBmsBleQueueTest, AdvanceOnEmptyQueueIsNoop) {
+  TestableDalyBmsBle bms;
+  bms.advance_command_queue_();
+  EXPECT_EQ(bms.queue_size(), 0);
+  EXPECT_FALSE(bms.command_pending());
+}
+
+TEST(DalyBmsBleQueueTest, ValidResponseAdvancesQueue) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+  bms.queue_command_(0x03, 0x0080, 41);
+
+  bms.on_daly_bms_ble_data(STATUS_FRAME_80_REG_2);
+
+  EXPECT_EQ(bms.queue_size(), 1);
+  EXPECT_FALSE(bms.command_pending());
+}
+
+TEST(DalyBmsBleQueueTest, InvalidStartByteDoesNotAdvanceQueue) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+
+  bms.on_daly_bms_ble_data({0xFF, 0x03, 0x00, 0x00, 0x00});
+
+  EXPECT_EQ(bms.queue_size(), 1);
+}
+
+TEST(DalyBmsBleQueueTest, BadCrcDoesNotAdvanceQueue) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+
+  auto bad_crc = STATUS_FRAME_80_REG_2;
+  bad_crc.back() ^= 0xFF;
+  bms.on_daly_bms_ble_data(bad_crc);
+
+  EXPECT_EQ(bms.queue_size(), 1);
+}
+
 }  // namespace esphome::daly_bms_ble::testing

--- a/tests/components/daly_bms_ble/test.host.yaml
+++ b/tests/components/daly_bms_ble/test.host.yaml
@@ -1,3 +1,4 @@
 daly_bms_ble:
   id: test_bms
   update_interval: 20s
+  response_timeout: 3s

--- a/tests/esp32-balancer-ble-example-faker.yaml
+++ b/tests/esp32-balancer-ble-example-faker.yaml
@@ -4,6 +4,7 @@ daly_bms_ble:
   - ble_client_id: client0
     id: bms0
     update_interval: 10s
+    response_timeout: 3s
 
 interval:
   - interval: 10s

--- a/tests/esp32-ble-alarms-faker.yaml
+++ b/tests/esp32-ble-alarms-faker.yaml
@@ -410,6 +410,7 @@ daly_bms_ble:
   - ble_client_id: client0
     id: bms0
     update_interval: 10s
+    response_timeout: 3s
 
 sensor:
   - platform: daly_bms_ble

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -46,6 +46,7 @@ daly_bms_ble:
     id: bms0
     password: 12345678
     update_interval: 10s
+    response_timeout: 3s
 
 binary_sensor:
   - platform: daly_bms_ble


### PR DESCRIPTION
## Problem

Switch states (charging/discharging MOS) are only contained in the settings frame, but settings were never polled. They were only decoded when received unsolicited. This meant switch states were never refreshed from hardware after the initial connect, and a protection event (overvoltage, overtemp, etc.) that caused the BMS to disable a MOSFET would not be reflected in the UI until the next reconnect.

Fixes #106, closes #28

## Solution

### Command queue (COMMAND_QUEUE)

A circular buffer of 10 slots serialises all BLE writes. The next command is only sent after a notification response is received for the previous one. A 3 s timeout advances the queue if no response arrives. The same pattern is used in the other projects in this organisation (esphome-apc-ups, esphome-pipsolar, etc.).

### Settings frame polling

`update()` now enqueues two reads per cycle: the status registers (as before) and the settings registers (addr `0x0080`, 41 registers, 82-byte response). The settings frame already contained the logic to publish switch and number states. It just was not being requested periodically.

### Optimistic updates with correction

Switches and numbers still publish optimistically on user interaction for immediate UI feedback. The next settings poll then corrects the state if the BMS reports something different, e.g. when a protection event has disabled a MOSFET.

## Test plan

- [ ] Connect to BMS, verify both status and settings frames are logged on every update interval
- [ ] Toggle charging/discharging switch, verify UI flips immediately and is confirmed or corrected by the next settings poll
- [ ] Simulate a protection event, verify switch flips back to OFF in UI after the next poll without user interaction
- [ ] Verify numbers (e.g. cell voltage thresholds) are updated from the settings frame
- [ ] Disconnect/reconnect, verify queue is cleared and polling resumes cleanly