### PR TITLE
Remove unused locally defined unit constant

### DIFF
--- a/components/daly_bms_ble/sensor.py
+++ b/components/daly_bms_ble/sensor.py
@@ -59,7 +59,6 @@ ICON_CELL_COUNT = "mdi:car-battery"
 ICON_CAPACITY_REMAINING = "mdi:battery-50"
 
 UNIT_AMPERE_HOURS = "Ah"
-UNIT_SECONDS = "s"
 
 CELLS = [f"cell_voltage_{i}" for i in range(1, 33)]
 TEMPERATURES = [f"temperature_{i}" for i in range(1, 9)]


### PR DESCRIPTION
## Summary

The `daly_bms_ble` sensor platform defined a local `UNIT_SECONDS = "s"` constant that is not referenced anywhere. The canonical `UNIT_SECOND` is available in `esphome.const`. This removes the unused duplicate.

| Local definition | Status |
|---|---|
| `UNIT_SECONDS = "s"` | removed (unused; `UNIT_SECOND` exists in `esphome.const`) |

**Affected files:** `daly_bms_ble/sensor`

No functional change.