### PR TITLE
Route responses by command address instead of frame length

### DIFF
--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -26,6 +26,8 @@ static const uint8_t DALY_FUNCTION_WRITE = 0x06;
 static const uint16_t DALY_COMMAND_REQ_STATUS_START = 0;
 static const uint16_t DALY_COMMAND_REQ_SETTINGS_START = 0x0080;
 static const uint16_t DALY_COMMAND_REQ_SETTINGS_COUNT = 41;
+static const uint16_t DALY_COMMAND_REQ_VERSION_START = 0x00A9;
+static const uint16_t DALY_COMMAND_REQ_PASSWORD = 0x00C9;
 static const uint16_t DALY_COMMAND_REQ_BALANCER_SWITCH = 0x00CF;
 
 static const uint8_t DALY_FRAME_LEN_STATUS_80_REGISTERS = 80 * 2;
@@ -305,6 +307,12 @@ void DalyBmsBle::on_daly_bms_ble_data(const std::vector<uint8_t> &data) {
       break;
     case DALY_COMMAND_REQ_SETTINGS_START:
       this->decode_settings_data_(data);
+      break;
+    case DALY_COMMAND_REQ_VERSION_START:
+      this->decode_version_data_(data);
+      break;
+    case DALY_COMMAND_REQ_PASSWORD:
+      this->decode_password_data_(data);
       break;
     case DALY_COMMAND_REQ_BALANCER_SWITCH:
       this->decode_balancer_switch_data_(data);

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -23,19 +23,18 @@ static const uint8_t DALY_FRAME_START2 = 0x03;
 static const uint8_t DALY_FUNCTION_READ = 0x03;
 static const uint8_t DALY_FUNCTION_WRITE = 0x06;
 
-static const uint16_t DALY_COMMAND_REQ_STATUS_START = 0;
+static const uint16_t DALY_COMMAND_REQ_STATUS_START = 0x0000;
 static const uint16_t DALY_COMMAND_REQ_SETTINGS_START = 0x0080;
-static const uint16_t DALY_COMMAND_REQ_SETTINGS_COUNT = 41;
 static const uint16_t DALY_COMMAND_REQ_VERSION_START = 0x00A9;
 static const uint16_t DALY_COMMAND_REQ_PASSWORD = 0x00C9;
 static const uint16_t DALY_COMMAND_REQ_BALANCER_SWITCH = 0x00CF;
 
 static const uint8_t DALY_FRAME_LEN_STATUS_80_REGISTERS = 80 * 2;
 static const uint8_t DALY_FRAME_LEN_STATUS_62_REGISTERS = 62 * 2;
-static const uint8_t DALY_FRAME_LEN_SETTINGS = 82;
-static const uint8_t DALY_FRAME_LEN_VERSIONS = 64;
-static const uint8_t DALY_FRAME_LEN_PASSWORD = 6;
-static const uint8_t DALY_FRAME_LEN_BALANCER_SWITCH = 2;
+static const uint8_t DALY_FRAME_LEN_SETTINGS = 41 * 2;
+static const uint8_t DALY_FRAME_LEN_VERSIONS = 32 * 2;
+static const uint8_t DALY_FRAME_LEN_PASSWORD = 3 * 2;
+static const uint8_t DALY_FRAME_LEN_BALANCER_SWITCH = 1 * 2;
 
 static const uint8_t MAX_RESPONSE_SIZE = 165;
 
@@ -266,8 +265,8 @@ void DalyBmsBle::update() {
   }
 
   this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_STATUS_START, this->status_registers_);
-  this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_SETTINGS_START, DALY_COMMAND_REQ_SETTINGS_COUNT);
-  this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_BALANCER_SWITCH, 1);
+  this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_SETTINGS_START, DALY_FRAME_LEN_SETTINGS / 2);
+  this->queue_command_(DALY_FUNCTION_READ, DALY_COMMAND_REQ_BALANCER_SWITCH, DALY_FRAME_LEN_BALANCER_SWITCH / 2);
   this->send_next_command_();
 #endif
 }

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -285,6 +285,7 @@ void DalyBmsBle::on_daly_bms_ble_data(const std::vector<uint8_t> &data) {
     return;
   }
 
+  uint16_t cmd_address = this->queue_.empty() ? 0xFFFF : this->queue_.front().address;
   this->advance_command_queue_();
 
   if (data[1] == DALY_FUNCTION_WRITE) {
@@ -298,27 +299,18 @@ void DalyBmsBle::on_daly_bms_ble_data(const std::vector<uint8_t> &data) {
     return;
   }
 
-  uint8_t frame_type = data[2];  // data length
-
-  switch (frame_type) {
-    case DALY_FRAME_LEN_STATUS_80_REGISTERS:
-    case DALY_FRAME_LEN_STATUS_62_REGISTERS:
+  switch (cmd_address) {
+    case DALY_COMMAND_REQ_STATUS_START:
       this->decode_status_data_(data);
       break;
-    case DALY_FRAME_LEN_SETTINGS:
+    case DALY_COMMAND_REQ_SETTINGS_START:
       this->decode_settings_data_(data);
       break;
-    case DALY_FRAME_LEN_BALANCER_SWITCH:
+    case DALY_COMMAND_REQ_BALANCER_SWITCH:
       this->decode_balancer_switch_data_(data);
       break;
-    case DALY_FRAME_LEN_VERSIONS:
-      this->decode_version_data_(data);
-      break;
-    case DALY_FRAME_LEN_PASSWORD:
-      this->decode_password_data_(data);
-      break;
     default:
-      ESP_LOGW(TAG, "Unhandled response received (frame_type 0x%02X): %s", frame_type,
+      ESP_LOGW(TAG, "Unhandled response received (addr=0x%04X, len=%zu): %s", cmd_address, data.size(),
                format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
   }
 }
@@ -334,6 +326,10 @@ void DalyBmsBle::decode_status_data_(const std::vector<uint8_t> &data) {
     return (uint64_t(daly_get_32bit(i + 0)) << 32) | (uint64_t(daly_get_32bit(i + 4)) << 0);
   };
 
+  if (data.size() != DALY_FRAME_LEN_STATUS_62_REGISTERS + 5 && data.size() != DALY_FRAME_LEN_STATUS_80_REGISTERS + 5) {
+    ESP_LOGW(TAG, "decode_status_data_: unexpected frame size %zu", data.size());
+    return;
+  }
   ESP_LOGI(TAG, "Status frame received (%zu bytes)", data.size());
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), 100).c_str());                      // NOLINT
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front() + 100, data.size() - 100).c_str());  // NOLINT
@@ -516,6 +512,10 @@ void DalyBmsBle::decode_settings_data_(const std::vector<uint8_t> &data) {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
 
+  if (data.size() != DALY_FRAME_LEN_SETTINGS + 5) {
+    ESP_LOGW(TAG, "decode_settings_data_: unexpected frame size %zu", data.size());
+    return;
+  }
   ESP_LOGI(TAG, "Settings frame received");
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
@@ -660,6 +660,10 @@ void DalyBmsBle::decode_settings_data_(const std::vector<uint8_t> &data) {
 }
 
 void DalyBmsBle::decode_balancer_switch_data_(const std::vector<uint8_t> &data) {
+  if (data.size() != DALY_FRAME_LEN_BALANCER_SWITCH + 5) {
+    ESP_LOGW(TAG, "decode_balancer_switch_data_: unexpected frame size %zu", data.size());
+    return;
+  }
   // Frame layout: D2 03 02 [val_hi] [val_lo] [crc_lo] [crc_hi]
   // Byte 3–4: register 0x00CF  (0: off, 1: on)
   bool state = (data[3] << 8 | data[4]) != 0;
@@ -668,6 +672,10 @@ void DalyBmsBle::decode_balancer_switch_data_(const std::vector<uint8_t> &data) 
 }
 
 void DalyBmsBle::decode_version_data_(const std::vector<uint8_t> &data) {
+  if (data.size() != DALY_FRAME_LEN_VERSIONS + 5) {
+    ESP_LOGW(TAG, "decode_version_data_: unexpected frame size %zu", data.size());
+    return;
+  }
   ESP_LOGI(TAG, "Software/hardware version frame received");
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 
@@ -699,6 +707,10 @@ void DalyBmsBle::decode_version_data_(const std::vector<uint8_t> &data) {
 }
 
 void DalyBmsBle::decode_password_data_(const std::vector<uint8_t> &data) {
+  if (data.size() != DALY_FRAME_LEN_PASSWORD + 5) {
+    ESP_LOGW(TAG, "decode_password_data_: unexpected frame size %zu", data.size());
+    return;
+  }
   ESP_LOGI(TAG, "Password frame received");
   ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), data.size()).c_str());  // NOLINT
 

--- a/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
+++ b/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
@@ -60,6 +60,28 @@ TEST(DalyBmsBleVersionTest, WrongFrameSizeIsRejected) {
   EXPECT_EQ(sw_version.state, "");
 }
 
+TEST(DalyBmsBleVersionTest, DispatchedViaOnData) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor sw_version;
+  bms.set_software_version_text_sensor(&sw_version);
+
+  bms.queue_command_(0x03, 0x00A9, 0x20);
+  bms.on_daly_bms_ble_data(VERSION_FRAME_1);
+
+  EXPECT_EQ(sw_version.state, "401012");
+}
+
+TEST(DalyBmsBleVersionTest, SecondFrameDispatchedViaOnData) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor sw_version;
+  bms.set_software_version_text_sensor(&sw_version);
+
+  bms.queue_command_(0x03, 0x00A9, 0x20);
+  bms.on_daly_bms_ble_data(VERSION_FRAME_2);
+
+  EXPECT_EQ(sw_version.state, "204012");
+}
+
 // ── Password frame (data_len=0x06) ───────────────────────────────────────────
 
 TEST(DalyBmsBlePasswordTest, NullSensorsDoNotCrash) {
@@ -70,6 +92,12 @@ TEST(DalyBmsBlePasswordTest, NullSensorsDoNotCrash) {
 TEST(DalyBmsBlePasswordTest, WrongFrameSizeIsRejected) {
   TestableDalyBmsBle bms;
   bms.decode_password_data_(SETTINGS_FRAME_1);
+}
+
+TEST(DalyBmsBlePasswordTest, DispatchedViaOnData) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x00C9, 0x03);
+  bms.on_daly_bms_ble_data(PASSWORD_FRAME_1);
 }
 
 // ── Settings frame (data_len=0x52) ───────────────────────────────────────────

--- a/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
+++ b/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
@@ -50,14 +50,14 @@ TEST(DalyBmsBleVersionTest, HardwareVersionFrame2) {
   EXPECT_EQ(hw_version.state, "SH39F003");
 }
 
-TEST(DalyBmsBleVersionTest, DispatchedViaOnData) {
+TEST(DalyBmsBleVersionTest, WrongFrameSizeIsRejected) {
   TestableDalyBmsBle bms;
-  bms.on_daly_bms_ble_data(VERSION_FRAME_1);
-}
+  text_sensor::TextSensor sw_version;
+  bms.set_software_version_text_sensor(&sw_version);
 
-TEST(DalyBmsBleVersionTest, SecondFrameDispatchedViaOnData) {
-  TestableDalyBmsBle bms;
-  bms.on_daly_bms_ble_data(VERSION_FRAME_2);
+  bms.decode_version_data_(BALANCER_SWITCH_FRAME_ON);
+
+  EXPECT_EQ(sw_version.state, "");
 }
 
 // ── Password frame (data_len=0x06) ───────────────────────────────────────────
@@ -67,9 +67,9 @@ TEST(DalyBmsBlePasswordTest, NullSensorsDoNotCrash) {
   bms.decode_password_data_(PASSWORD_FRAME_1);
 }
 
-TEST(DalyBmsBlePasswordTest, DispatchedViaOnData) {
+TEST(DalyBmsBlePasswordTest, WrongFrameSizeIsRejected) {
   TestableDalyBmsBle bms;
-  bms.on_daly_bms_ble_data(PASSWORD_FRAME_1);
+  bms.decode_password_data_(SETTINGS_FRAME_1);
 }
 
 // ── Settings frame (data_len=0x52) ───────────────────────────────────────────
@@ -421,7 +421,23 @@ TEST(DalyBmsBleSettingsTest, NullSensorsDoNotCrash) {
 
 TEST(DalyBmsBleSettingsTest, DispatchedViaOnData) {
   TestableDalyBmsBle bms;
+  TestSwitch charging;
+  bms.set_charging_switch(&charging);
+
+  bms.queue_command_(0x03, 0x0080, 41);
   bms.on_daly_bms_ble_data(SETTINGS_FRAME_1);
+
+  EXPECT_TRUE(charging.state);
+}
+
+TEST(DalyBmsBleSettingsTest, WrongFrameSizeIsRejected) {
+  TestableDalyBmsBle bms;
+  TestSwitch charging;
+  bms.set_charging_switch(&charging);
+
+  bms.decode_settings_data_(BALANCER_SWITCH_FRAME_ON);
+
+  EXPECT_FALSE(charging.state);
 }
 
 // ── Status frame, 80 registers (data_len=0xA0) ───────────────────────────────
@@ -637,7 +653,23 @@ TEST(DalyBmsBleStatus80RegTest, NullSensorsDoNotCrash) {
 
 TEST(DalyBmsBleStatus80RegTest, DispatchedViaOnData) {
   TestableDalyBmsBle bms;
+  sensor::Sensor voltage;
+  bms.set_total_voltage_sensor(&voltage);
+
+  bms.queue_command_(0x03, 0x0000, 80);
   bms.on_daly_bms_ble_data(STATUS_FRAME_80_REG_2);
+
+  EXPECT_NEAR(voltage.state, 52.5f, 0.01f);
+}
+
+TEST(DalyBmsBleStatus80RegTest, WrongFrameSizeIsRejected) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor charging;
+  bms.set_charging_binary_sensor(&charging);
+
+  bms.decode_status_data_(BALANCER_SWITCH_FRAME_ON);
+
+  EXPECT_FALSE(charging.state);
 }
 
 // ── Status frame, 62 registers (data_len=0x7C) ───────────────────────────────
@@ -745,7 +777,13 @@ TEST(DalyBmsBleStatus62RegTest, NullSensorsDoNotCrash) {
 
 TEST(DalyBmsBleStatus62RegTest, DispatchedViaOnData) {
   TestableDalyBmsBle bms;
+  sensor::Sensor voltage;
+  bms.set_total_voltage_sensor(&voltage);
+
+  bms.queue_command_(0x03, 0x0000, 62);
   bms.on_daly_bms_ble_data(STATUS_FRAME_62_REG_NO_ALARMS);
+
+  EXPECT_NEAR(voltage.state, 27.1f, 0.01f);
 }
 
 // ── Alarm decoding ───────────────────────────────────────────────────────────
@@ -872,6 +910,7 @@ TEST(DalyBmsBleBalancerSwitchTest, DispatchedViaOnDataOn) {
   TestSwitch balancer;
   bms.set_balancer_switch(&balancer);
 
+  bms.queue_command_(0x03, 0x00CF, 1);
   bms.on_daly_bms_ble_data(BALANCER_SWITCH_FRAME_ON);
 
   EXPECT_TRUE(balancer.state);
@@ -882,7 +921,18 @@ TEST(DalyBmsBleBalancerSwitchTest, DispatchedViaOnDataOff) {
   TestSwitch balancer;
   bms.set_balancer_switch(&balancer);
 
+  bms.queue_command_(0x03, 0x00CF, 1);
   bms.on_daly_bms_ble_data(BALANCER_SWITCH_FRAME_OFF);
+
+  EXPECT_FALSE(balancer.state);
+}
+
+TEST(DalyBmsBleBalancerSwitchTest, WrongFrameSizeIsRejected) {
+  TestableDalyBmsBle bms;
+  TestSwitch balancer;
+  bms.set_balancer_switch(&balancer);
+
+  bms.decode_balancer_switch_data_(SETTINGS_FRAME_1);
 
   EXPECT_FALSE(balancer.state);
 }


### PR DESCRIPTION
## Summary

- Replace `switch (data[2])` (frame length) with `switch (queue_.front().address)` — the queued command address is the authoritative source for which decoder to call, since Modbus RTU has no transaction ID
- Add frame size guard clauses to all five decoders using the existing `DALY_FRAME_LEN_*` constants; status decoder accepts both valid lengths (62 and 80 registers)
- Update `DispatchedViaOnData` tests to pre-queue the matching command and assert on decoded state; add `WrongFrameSizeIsRejected` tests for all decoders

## Test plan

- [ ] `bash run-cpp-tests.sh` → 115/115 passed
- [ ] Flash and verify status, settings and balancer switch frames are decoded correctly on device