### PR TITLE
Add online_status sensor with unavailability tracking

### DIFF
--- a/components/daly_bms_ble/binary_sensor.py
+++ b/components/daly_bms_ble/binary_sensor.py
@@ -2,6 +2,8 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+
 from . import CONF_DALY_BMS_BLE_ID, DALY_BMS_BLE_COMPONENT_SCHEMA
 from .const import (
     CONF_CHARGING,
@@ -17,11 +19,16 @@ DEPENDENCIES = ["daly_bms_ble"]
 CODEOWNERS = ["@syssi"]
 
 CONF_BALANCING = "balancing"
+CONF_ONLINE_STATUS = "online_status"
 
 ICON_BALANCING = "mdi:battery-heart-variant"
 
 # key: binary_sensor_schema kwargs
 BINARY_SENSOR_DEFS = {
+    CONF_ONLINE_STATUS: {
+        "device_class": DEVICE_CLASS_CONNECTIVITY,
+        "entity_category": ENTITY_CATEGORY_DIAGNOSTIC,
+    },
     CONF_BALANCING: {
         "icon": ICON_BALANCING,
     },

--- a/components/daly_bms_ble/binary_sensor.py
+++ b/components/daly_bms_ble/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-
 from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_DALY_BMS_BLE_ID, DALY_BMS_BLE_COMPONENT_SCHEMA

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -12,6 +12,7 @@
 namespace esphome::daly_bms_ble {
 
 static const char *const TAG = "daly_bms_ble";
+static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
 static const uint16_t DALY_BMS_SERVICE_UUID = 0xFFF0;
 static const uint16_t DALY_BMS_NOTIFY_CHARACTERISTIC_UUID = 0xFFF1;
@@ -293,6 +294,7 @@ void DalyBmsBle::loop() {
 }
 
 void DalyBmsBle::update() {
+  this->track_online_status_();
 #ifdef USE_ESP32
   if (this->node_state != espbt::ClientState::ESTABLISHED) {
     ESP_LOGW(TAG, "[%s] Not connected", ADDR_STR(this->parent_->address_str()));
@@ -342,6 +344,7 @@ void DalyBmsBle::on_daly_bms_ble_data(const std::vector<uint8_t> &data) {
 
   uint16_t cmd_address = this->queue_.empty() ? 0xFFFF : this->queue_.front().address;
   this->advance_command_queue_();
+  this->reset_online_status_tracker_();
 
   if (data[1] == DALY_FUNCTION_WRITE) {
     ESP_LOGD(TAG, "Write register acknowledged (reg=0x%02X%02X, value=0x%02X%02X)", data[2], data[3], data[4], data[5]);
@@ -829,6 +832,7 @@ void DalyBmsBle::decode_password_data_(const std::vector<uint8_t> &data) {
 void DalyBmsBle::dump_config() {  // NOLINT(google-readability-function-size,readability-function-size)
   ESP_LOGCONFIG(TAG, "DalyBmsBle:");
 
+  LOG_BINARY_SENSOR("", "Online Status", this->online_status_binary_sensor_);
   LOG_BINARY_SENSOR("", "Charging", this->charging_binary_sensor_);
   LOG_BINARY_SENSOR("", "Discharging", this->discharging_binary_sensor_);
 
@@ -920,6 +924,55 @@ void DalyBmsBle::dump_config() {  // NOLINT(google-readability-function-size,rea
   LOG_TEXT_SENSOR("", "Battery Status", this->battery_status_text_sensor_);
   LOG_TEXT_SENSOR("", "Software Version", this->software_version_text_sensor_);
   LOG_TEXT_SENSOR("", "Hardware Version", this->hardware_version_text_sensor_);
+}
+
+void DalyBmsBle::track_online_status_() {
+  if (this->no_response_count_ < MAX_NO_RESPONSE_COUNT)
+    this->no_response_count_++;
+  if (this->no_response_count_ == MAX_NO_RESPONSE_COUNT) {
+    this->publish_device_unavailable_();
+    this->no_response_count_++;
+  }
+}
+
+void DalyBmsBle::reset_online_status_tracker_() {
+  this->no_response_count_ = 0;
+  this->publish_state_(this->online_status_binary_sensor_, true);
+}
+
+void DalyBmsBle::publish_device_unavailable_() {
+  this->publish_state_(this->online_status_binary_sensor_, false);
+  this->publish_state_(this->total_voltage_sensor_, NAN);
+  this->publish_state_(this->current_sensor_, NAN);
+  this->publish_state_(this->power_sensor_, NAN);
+  this->publish_state_(this->charging_power_sensor_, NAN);
+  this->publish_state_(this->discharging_power_sensor_, NAN);
+  this->publish_state_(this->error_bitmask_sensor_, NAN);
+  this->publish_state_(this->state_of_charge_sensor_, NAN);
+  this->publish_state_(this->charging_cycles_sensor_, NAN);
+  this->publish_state_(this->min_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->max_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->min_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->max_voltage_cell_sensor_, NAN);
+  this->publish_state_(this->delta_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->average_cell_voltage_sensor_, NAN);
+  this->publish_state_(this->cell_count_sensor_, NAN);
+  this->publish_state_(this->temperature_sensors_sensor_, NAN);
+  this->publish_state_(this->capacity_remaining_sensor_, NAN);
+  this->publish_state_(this->balance_current_sensor_, NAN);
+  this->publish_state_(this->mosfet_temperature_sensor_, NAN);
+  this->publish_state_(this->board_temperature_sensor_, NAN);
+  this->publish_state_(this->max_battery_temperature_sensor_, NAN);
+  this->publish_state_(this->max_battery_temperature_probe_sensor_, NAN);
+  this->publish_state_(this->min_battery_temperature_sensor_, NAN);
+  this->publish_state_(this->min_battery_temperature_probe_sensor_, NAN);
+  this->publish_state_(this->energy_sensor_, NAN);
+  for (auto &cell : this->cells_)
+    this->publish_state_(cell.cell_voltage_sensor_, NAN);
+  for (auto &temp : this->temperatures_)
+    this->publish_state_(temp.temperature_sensor_, NAN);
+  this->publish_state_(this->battery_status_text_sensor_, "Offline");
+  this->publish_state_(this->errors_text_sensor_, "Offline");
 }
 
 void DalyBmsBle::publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state) {

--- a/components/daly_bms_ble/daly_bms_ble.cpp
+++ b/components/daly_bms_ble/daly_bms_ble.cpp
@@ -227,8 +227,6 @@ void DalyBmsBle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t g
 
       this->queue_.reset();
 
-      // this->publish_state_(this->voltage_sensor_, NAN);
-
       if (this->char_notify_handle_ != 0) {
         auto status = esp_ble_gattc_unregister_for_notify(this->parent()->get_gattc_if(),
                                                           this->parent()->get_remote_bda(), this->char_notify_handle_);

--- a/components/daly_bms_ble/daly_bms_ble.h
+++ b/components/daly_bms_ble/daly_bms_ble.h
@@ -32,6 +32,9 @@ class DalyBmsBle :
   void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
+  void set_online_status_binary_sensor(binary_sensor::BinarySensor *online_status_binary_sensor) {
+    online_status_binary_sensor_ = online_status_binary_sensor;
+  }
   void set_balancing_binary_sensor(binary_sensor::BinarySensor *balancing_binary_sensor) {
     balancing_binary_sensor_ = balancing_binary_sensor;
   }
@@ -137,6 +140,7 @@ class DalyBmsBle :
   void set_status_registers(uint8_t protocol_version) { this->status_registers_ = protocol_version; }
 
  protected:
+  binary_sensor::BinarySensor *online_status_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *balancing_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *charging_binary_sensor_{nullptr};
   binary_sensor::BinarySensor *discharging_binary_sensor_{nullptr};
@@ -248,6 +252,7 @@ class DalyBmsBle :
   uint16_t char_notify_handle_{0};
   uint16_t char_command_handle_{0};
 #endif
+  uint8_t no_response_count_{0};
   uint32_t password_ = 12345678;
   uint8_t status_registers_{62};
   uint8_t protocol_version_{0xD2};
@@ -261,6 +266,9 @@ class DalyBmsBle :
   void decode_p81_cells_data_(const std::vector<uint8_t> &data);
   void decode_p81_status_data_(const std::vector<uint8_t> &data);
   void decode_p81_version_data_(const std::vector<uint8_t> &data);
+  void publish_device_unavailable_();
+  void reset_online_status_tracker_();
+  void track_online_status_();
   void publish_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);
   void publish_state_(sensor::Sensor *sensor, float value);
   void publish_state_(number::Number *obj, float value);

--- a/esp32-ble-example-multiple-devices.yaml
+++ b/esp32-ble-example-multiple-devices.yaml
@@ -87,6 +87,9 @@ daly_bms_ble:
 binary_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
+    online_status:
+      name: "online status"
+      device_id: device0
     balancing:
       name: "balancing"
       device_id: device0
@@ -99,6 +102,9 @@ binary_sensor:
 
   - platform: daly_bms_ble
     daly_bms_ble_id: bms1
+    online_status:
+      name: "online status"
+      device_id: device1
     balancing:
       name: "balancing"
       device_id: device1

--- a/esp32-ble-example.yaml
+++ b/esp32-ble-example.yaml
@@ -67,6 +67,8 @@ daly_bms_ble:
 binary_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
+    online_status:
+      name: "online status"
     balancing:
       name: "balancing"
     charging:

--- a/esp32-ble-p81-example.yaml
+++ b/esp32-ble-p81-example.yaml
@@ -63,6 +63,8 @@ daly_bms_ble:
 binary_sensor:
   - platform: daly_bms_ble
     daly_bms_ble_id: bms0
+    online_status:
+      name: "online status"
     balancing:
       name: "balancing"
     charging:

--- a/tests/components/daly_bms_ble/common.h
+++ b/tests/components/daly_bms_ble/common.h
@@ -17,6 +17,10 @@ struct TestNumber : number::Number {
 class TestableDalyBmsBle : public DalyBmsBle {
  public:
   using DalyBmsBle::build_frame_;
+  using DalyBmsBle::track_online_status_;
+  using DalyBmsBle::reset_online_status_tracker_;
+  using DalyBmsBle::publish_device_unavailable_;
+  uint8_t get_no_response_count() const { return no_response_count_; }
   using DalyBmsBle::decode_status_data_;
   using DalyBmsBle::decode_settings_data_;
   using DalyBmsBle::decode_balancer_switch_data_;

--- a/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
+++ b/tests/components/daly_bms_ble/daly_bms_ble_test.cpp
@@ -1129,4 +1129,172 @@ TEST(DalyBmsBleQueueTest, BadCrcDoesNotAdvanceQueue) {
   EXPECT_EQ(bms.queue_size(), 1);
 }
 
+// ── Online status tracker ─────────────────────────────────────────────────────
+
+TEST(DalyBmsBleOnlineStatusTrackerTest, ReachesThreshold) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(DalyBmsBleOnlineStatusTrackerTest, DoesNotRepeatAfterThreshold) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+
+  bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 11);
+}
+
+TEST(DalyBmsBleOnlineStatusTrackerTest, ResetRestoresOnlineStatus) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+
+  bms.reset_online_status_tracker_();
+  EXPECT_TRUE(online_status.state);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(DalyBmsBleOnlineStatusTrackerTest, CanRetriggerAfterReset) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  bms.reset_online_status_tracker_();
+
+  for (int i = 0; i < 10; i++)
+    bms.track_online_status_();
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(DalyBmsBleOnlineStatusTrackerTest, ValidFrameResetsCounter) {
+  TestableDalyBmsBle bms;
+  bms.queue_command_(0x03, 0x0000, 62);
+
+  for (int i = 0; i < 5; i++)
+    bms.track_online_status_();
+  EXPECT_EQ(bms.get_no_response_count(), 5);
+
+  bms.on_daly_bms_ble_data(STATUS_FRAME_62_REG_NO_ALARMS);
+  EXPECT_EQ(bms.get_no_response_count(), 0);
+}
+
+TEST(DalyBmsBleOnlineStatusTrackerTest, NotYetAtThresholdStaysOnline) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  for (int i = 0; i < 9; i++)
+    bms.track_online_status_();
+
+  EXPECT_TRUE(online_status.state);
+}
+
+// ── publish_device_unavailable_ ───────────────────────────────────────────────
+
+TEST(DalyBmsBlePublishDeviceUnavailableTest, SetsOnlineStatusFalse) {
+  TestableDalyBmsBle bms;
+  binary_sensor::BinarySensor online_status;
+  bms.set_online_status_binary_sensor(&online_status);
+
+  online_status.publish_state(true);
+  bms.publish_device_unavailable_();
+
+  EXPECT_FALSE(online_status.state);
+}
+
+TEST(DalyBmsBlePublishDeviceUnavailableTest, SetsNumericSensorsToNAN) {
+  TestableDalyBmsBle bms;
+  sensor::Sensor total_voltage, current, power, charging_power, discharging_power;
+  sensor::Sensor error_bitmask, state_of_charge, charging_cycles, capacity_remaining, energy;
+  bms.set_total_voltage_sensor(&total_voltage);
+  bms.set_current_sensor(&current);
+  bms.set_power_sensor(&power);
+  bms.set_charging_power_sensor(&charging_power);
+  bms.set_discharging_power_sensor(&discharging_power);
+  bms.set_error_bitmask_sensor(&error_bitmask);
+  bms.set_state_of_charge_sensor(&state_of_charge);
+  bms.set_charging_cycles_sensor(&charging_cycles);
+  bms.set_capacity_remaining_sensor(&capacity_remaining);
+  bms.set_energy_sensor(&energy);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(total_voltage.state));
+  EXPECT_TRUE(std::isnan(current.state));
+  EXPECT_TRUE(std::isnan(power.state));
+  EXPECT_TRUE(std::isnan(charging_power.state));
+  EXPECT_TRUE(std::isnan(discharging_power.state));
+  EXPECT_TRUE(std::isnan(error_bitmask.state));
+  EXPECT_TRUE(std::isnan(state_of_charge.state));
+  EXPECT_TRUE(std::isnan(charging_cycles.state));
+  EXPECT_TRUE(std::isnan(capacity_remaining.state));
+  EXPECT_TRUE(std::isnan(energy.state));
+}
+
+TEST(DalyBmsBlePublishDeviceUnavailableTest, SetsCellAndTempSensorsToNAN) {
+  TestableDalyBmsBle bms;
+  sensor::Sensor cell0, cell1, temp0, temp1;
+  bms.set_cell_voltage_sensor(0, &cell0);
+  bms.set_cell_voltage_sensor(1, &cell1);
+  bms.set_temperature_sensor(0, &temp0);
+  bms.set_temperature_sensor(1, &temp1);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_TRUE(std::isnan(cell0.state));
+  EXPECT_TRUE(std::isnan(cell1.state));
+  EXPECT_TRUE(std::isnan(temp0.state));
+  EXPECT_TRUE(std::isnan(temp1.state));
+}
+
+TEST(DalyBmsBlePublishDeviceUnavailableTest, SetsDynamicTextSensorsToOffline) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor battery_status, errors;
+  bms.set_battery_status_text_sensor(&battery_status);
+  bms.set_errors_text_sensor(&errors);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(battery_status.state, "Offline");
+  EXPECT_EQ(errors.state, "Offline");
+}
+
+TEST(DalyBmsBlePublishDeviceUnavailableTest, LeavesStaticTextSensorsUnchanged) {
+  TestableDalyBmsBle bms;
+  text_sensor::TextSensor software_version, hardware_version;
+  software_version.publish_state("401012");
+  hardware_version.publish_state("BMS");
+  bms.set_software_version_text_sensor(&software_version);
+  bms.set_hardware_version_text_sensor(&hardware_version);
+
+  bms.publish_device_unavailable_();
+
+  EXPECT_EQ(software_version.state, "401012");
+  EXPECT_EQ(hardware_version.state, "BMS");
+}
+
+TEST(DalyBmsBlePublishDeviceUnavailableTest, NullSensorsDoNotCrash) {
+  TestableDalyBmsBle bms;
+
+  EXPECT_NO_FATAL_FAILURE(bms.publish_device_unavailable_());
+}
+
 }  // namespace esphome::daly_bms_ble::testing

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -55,11 +55,12 @@ class TestSensorLists:
 
 class TestBinarySensorConstants:
     def test_binary_sensor_defs_dict(self):
+        assert binary_sensor.CONF_ONLINE_STATUS in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_BALANCING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_CHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_DISCHARGING in binary_sensor.BINARY_SENSOR_DEFS
         assert binary_sensor.CONF_PRECHARGING in binary_sensor.BINARY_SENSOR_DEFS
-        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 4
+        assert len(binary_sensor.BINARY_SENSOR_DEFS) == 5
 
 
 class TestSwitchConstants:


### PR DESCRIPTION
## Summary

- Adds `online_status` binary sensor (`device_class: connectivity`, `entity_category: diagnostic`)
- After 10 consecutive `update()` cycles without a valid BMS frame, marks the device unavailable: `online_status` → false, all numeric sensors → NaN, dynamic text sensors → "Offline"
- Static identity sensors (`software_version`, `hardware_version`) are left unchanged
- Integrates `track_online_status_()` at the start of `update()` and `reset_online_status_tracker_()` in `on_daly_bms_ble_data()` after CRC validation and queue advance

## Test plan

- [x] C++ unit tests: `DalyBmsBleOnlineStatusTrackerTest` (6 tests) and `DalyBmsBlePublishDeviceUnavailableTest` (6 tests) — all 171 tests pass
- [x] pytest schema validation passes (5 binary sensor defs)
- [x] `esp32-ble-example.yaml` and `esp32-ble-example-multiple-devices.yaml` updated with `online_status` sensor