### PR TITLE
Drop Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ permissions:
 
 env:
   FORCE_COLOR: 1
-  DEFAULT_PYTHON: "3.11"
-  PYUPGRADE_TARGET: "--py311-plus"
+  DEFAULT_PYTHON: "3.12"
+  PYUPGRADE_TARGET: "--py312-plus"
 
 concurrency:
   # yamllint disable-line rule:line-length

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v3.19.1
     hooks:
       - id: pyupgrade
-        args: [--py311-plus]
+        args: [--py312-plus]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.35.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 testpaths = ["tests"]
 
 [tool.pylint.MAIN]
-py-version = "3.11"
+py-version = "3.12"
 persistent = false
 
 [tool.pylint.REPORTS]
@@ -44,7 +44,7 @@ expected-line-ending-format = "LF"
 
 [tool.ruff]
 required-version = ">=0.5.5"
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Summary

- Bump `DEFAULT_PYTHON` to `3.12` and `PYUPGRADE_TARGET` to `--py312-plus` in `.github/workflows/ci.yaml`
- Update `pyupgrade` args to `--py312-plus` in `.pre-commit-config.yaml`
- Update `tool.pylint` `py-version` to `3.12` and `tool.ruff` `target-version` to `py312` in `pyproject.toml`

Mirrors [esphome/esphome#17280](https://github.com/esphome/esphome/pull/17280).

## Test plan

- [ ] CI passes with Python 3.12